### PR TITLE
Init Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,7 @@
+version: 2.1
+orbs:
+  node: circleci/node@3.0.0
+workflows:
+  node-tests:
+    jobs:
+      - node/test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: circleci/node:7.10-jessie-browsers
+      - image: circleci/node:latest
     steps:
       - checkout
       - node/install-packages:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,5 @@ jobs:
       - checkout
       - node/install-packages:
           pkg-manager: yarn
-      - run:
-          command: yarn run test
-          name: Run YARN tests
+      - run: yarn install
+      - run: yarn test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,3 @@ jobs:
       - run:
           command: yarn run test
           name: Run YARN tests
-workflows:
-  test_my_app:
-    jobs:
-      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,10 +2,9 @@ version: 2.1
 orbs:
   node: circleci/node@4.0.0
 jobs:
-  test:
-    executor:
-      name: node/default
-      tag: '13'
+  build:
+    docker:
+      - image: circleci/node:latest
     steps:
       - checkout
       - node/install-packages:
@@ -13,7 +12,3 @@ jobs:
       - run:
           command: yarn run test
           name: Run YARN tests
-workflows:
-  test_my_app:
-    jobs:
-      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,19 @@
 version: 2.1
-
 orbs:
   node: circleci/node@4.0.0
-
 jobs:
   test:
-    docker:
-      - image: cimg/node:<node-version>
+    executor:
+      name: node/default
+      tag: '13'
     steps:
       - checkout
-      - node/install:
-          install-yarn: true
-      - run: node --version
-      - node/install-packages # Utilize commands in steps
+      - node/install-packages:
+          pkg-manager: yarn
+      - run:
+          command: yarn run test
+          name: Run YARN tests
+workflows:
+  test_my_app:
+    jobs:
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,7 @@ jobs:
       - image: circleci/node:latest
     steps:
       - checkout
-      - node/install-packages:
-          pkg-manager: yarn
+      - run: yarn deps
       - run:
           command: yarn run test
           name: Run YARN tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,12 +2,14 @@ version: 2.1
 orbs:
   node: circleci/node@4.0.0
 jobs:
-  build:
-    docker:
-      - image: circleci/node:latest
+  test:
+    executor:
+      name: node/default
+      tag: '13'
     steps:
       - checkout
       - node/install-packages:
           pkg-manager: yarn
-      - run: yarn install
-      - run: yarn test
+      - run:
+          command: yarn run test
+          name: Run YARN tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,4 @@ jobs:
     steps:
       - checkout
       - run: yarn deps
-      - run:
-          command: yarn run test
-          name: Run YARN tests
+      - run: yarn run test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
           install-yarn: true
       - run: node --version
 orbs:
-  node: circleci/node@x.y
+  node: circleci/node@4.0.0
 version: 2.1
 workflows:
   test_my_app:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,15 @@
+version: 2.1
+
+orbs:
+  node: circleci/node@4.0.0
+
 jobs:
-  install-node-example:
+  test:
     docker:
-      - image: 'cimg/base:stable'
+      - image: cimg/node:<node-version>
     steps:
       - checkout
       - node/install:
           install-yarn: true
       - run: node --version
-orbs:
-  node: circleci/node@4.0.0
-version: 2.1
-workflows:
-  test_my_app:
-    jobs:
-      - install-node-example
+      - node/install-packages # Utilize commands in steps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,10 +2,9 @@ version: 2.1
 orbs:
   node: circleci/node@4.0.0
 jobs:
-  test:
-    executor:
-      name: node/default
-      tag: '13'
+  build:
+    docker:
+      - image: circleci/node:7.10-jessie-browsers
     steps:
       - checkout
       - node/install-packages:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,16 @@
-version: 2.1
+jobs:
+  install-node-example:
+    docker:
+      - image: 'cimg/base:stable'
+    steps:
+      - checkout
+      - node/install:
+          install-yarn: true
+      - run: node --version
 orbs:
-  node: circleci/node@3.0.0
+  node: circleci/node@x.y
+version: 2.1
 workflows:
-  node-tests:
+  test_my_app:
     jobs:
-      - node/test
+      - install-node-example

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,3 +13,7 @@ jobs:
       - run:
           command: yarn run test
           name: Run YARN tests
+workflows:
+  test_my_app:
+    jobs:
+      - test


### PR DESCRIPTION
**Part of https://github.com/HHS/Head-Start-TTADP/issues/12**
Add initial configuration for circle ci, run FE and BE tests.  There's still a lot to do on this ticket in forthcoming PRs.  See the issue for details.

**Proposed changes**
- Add circle ci config file
- [x] Tested in circle ci, most recent job passes https://app.circleci.com/pipelines/github/adhocteam/Head-Start-TTADP/21/workflows/5729d225-dc68-4676-858d-33d84cc9d2da/jobs/21
