### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,5 +5,8 @@
 Closes https://github.com/HHS/Head-Start-TTADP/issues/0
 
 **Checklist**
-- [ ] Tested by
-- [ ] Documented by
+<!-- Add details to each completed item -->
+- [ ] Meets issue criteria
+- [ ] Code tested
+- [ ] Documentation updated (e.g. Readme, infrastructure and data diagrams, API docs)
+- [ ] Meets accessibility standards

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,10 @@
 **Description of change**
 
 
-**Original issue(s)**
+**How to test**
+
+
+**Issue(s)**
 Closes https://github.com/HHS/Head-Start-TTADP/issues/0
 
 **Checklist**

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,8 @@
 **Description of change**
-<!-- Provide a summary of proposed change and context. -->
 
 
 **Original issue(s)**
-<!-- Remove closes keyword if you do NOT want to automatically close the issue. -->
 Closes https://github.com/HHS/Head-Start-TTADP/issues/0
-
 
 **Checklist**
 - [ ] Tested by

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,12 @@
+**Description of change**
+<!-- Provide a summary of proposed change and context. -->
+
+
+**Original issue(s)**
+<!-- Remove closes keyword if you do NOT want to automatically close the issue. -->
+Closes https://github.com/HHS/Head-Start-TTADP/issues/0
+
+
+**Checklist**
+- [ ] Tested by
+- [ ] Documented by


### PR DESCRIPTION
This adds a super minimal default PR template for discussion and iteration. Well, I'm pretty sure adding it to `.github/` will still allow it to be the default-- I guess we'll see.

I'm a big fan of PR templates; I think they save time and they remind me to include testing details and documentation. I also love the `closes` keyword for automatically closing related tickets.

----
**Description of change**


**How to test**


**Issue(s)**
Closes https://github.com/HHS/Head-Start-TTADP/issues/0

**Checklist**
<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] Code tested
- [ ] Documentation updated (e.g. Readme, infrastructure and data diagrams, API docs)
- [ ] Meets accessibility standards
