### PR TITLE
Specify node version in docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:12.18.3
     steps:
       - checkout
       - run: yarn deps


### PR DESCRIPTION
**Description of change**
I think this fixes build problem caused by node version mismatch https://app.circleci.com/pipelines/github/adhocteam/Head-Start-TTADP/54/workflows/da2a6e3e-f944-4c10-9a7a-9e508073448d/jobs/54

**How to test**
green build https://app.circleci.com/pipelines/github/adhocteam/Head-Start-TTADP/61/workflows/e04b1c38-0cd0-4aa1-99a4-aaeda36aefbf/jobs/61

**Issue(s)**
n/a

**Checklist**
<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] Code tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
