### PR TITLE
Remove 'Closes' from the PR template.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@
 
 
 **Issue(s)**
-Closes https://github.com/HHS/Head-Start-TTADP/issues/0
+* https://github.com/HHS/Head-Start-TTADP/issues/0
 
 **Checklist**
 <!-- Add details to each completed item -->


### PR DESCRIPTION
**Description of change**

Remove `Closes` keyword from the issues list to prevent auto-closing HHS issues before the relevant code has been delivered to the HHS repo. Keeping the linking between HHS issue and the first PR merging features to the adhoc/main branch is still desired.


**How to test**
N/A

**Issue(s)**
No related issues

**Checklist**
N/A