### PR TITLE
CI: Cache yarn.lock

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,31 +6,35 @@ executors:
     # for docker you must specify an image to use for the primary container
     docker:
       - image: circleci/node:12.18
+commands:
+  create_combined_yarnlock:
+  description: "Concatenate all yarn.json files into single file.
+    File is used as checksum source for part of caching key."
+  parameters:
+    filename:
+      type: string
+      default: "combined-yarnlock.txt"
+  steps:
+    - run:
+        name: Combine package-lock.json files to single file
+        command: cat yarn.lock frontend/yarn.lock > << parameters.filename >>
 jobs:
   build:
     # Each job must declare an executor
     executor: docker-executor
     steps:
       - checkout
+      - create_combined_yarnlock
       - restore_cache:
           keys:
-            - v1-yarn-backend-deps-{{ checksum "yarn.lock" }}
+            - v1-yarn-deps-{{ checksum "combined-yarnlock.txt" }}
             # If no exact match is found, partial cache restore with latest
-            - v1-yarn-backend-deps-
-      - restore_cache:
-          keys:
-            - v1-yarn-frontend-deps-{{ checksum "yarn.lock" }}
-            # If no exact match is found, partial cache restore with latest
-            - v1-yarn-frontend-deps-
+            - v1-yarn-deps-
       - run: yarn deps
       - save_cache:
           paths:
-            - ./node_modules
-          key: v1-yarn-backend-deps-{{ checksum "yarn.lock" }}
-      - save_cache:
-          paths:
-            - ./frontend/node_modules
-          key: v1-yarn-frontend-deps-{{ checksum "yarn.lock" }}
+            - combined-yarnlock.txt
+          key: v1-yarn-deps-{{ checksum "combined-yarnlock.txt" }}
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,16 +8,16 @@ executors:
       - image: circleci/node:12.18
 commands:
   create_combined_yarnlock:
-  description: "Concatenate all yarn.json files into single file.
-    File is used as checksum source for part of caching key."
-  parameters:
-    filename:
-      type: string
-      default: "combined-yarnlock.txt"
-  steps:
-    - run:
-        name: Combine package-lock.json files to single file
-        command: cat yarn.lock frontend/yarn.lock > << parameters.filename >>
+    description: "Concatenate all yarn.json files into single file.
+      File is used as checksum source for part of caching key."
+    parameters:
+      filename:
+        type: string
+        default: "combined-yarnlock.txt"
+    steps:
+      - run:
+          name: Combine package-lock.json files to single file
+          command: cat yarn.lock frontend/yarn.lock > << parameters.filename >>
 jobs:
   build:
     # Each job must declare an executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,25 @@ jobs:
     executor: docker-executor
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - v1-yarn-backend-deps-{{ checksum "yarn.lock" }}
+            # If no exact match is found, partial cache restore with latest
+            - v1-yarn-backend-deps-
+      - restore_cache:
+          keys:
+            - v1-yarn-frontend-deps-{{ checksum "yarn.lock" }}
+            # If no exact match is found, partial cache restore with latest
+            - v1-yarn-frontend-deps-
       - run: yarn deps
+      - save_cache:
+          paths:
+            - ./node_modules
+          key: v1-yarn-backend-deps-{{ checksum "yarn.lock" }}
+      - save_cache:
+          paths:
+            - ./frontend/node_modules
+          key: v1-yarn-frontend-deps-{{ checksum "yarn.lock" }}
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ commands:
       - run:
           name: Combine package-lock.json files to single file
           command: cat yarn.lock frontend/yarn.lock > << parameters.filename >>
+      - run: tail -n 10 combined-yarnlock.txt
 jobs:
   build:
     # Each job must declare an executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,9 @@ jobs:
       - create_combined_yarnlock
       - restore_cache:
           keys:
+            # To manually bust the cache, increment the version numbers e.g. v2-yarn...
             - v1-yarn-deps-{{ checksum "combined-yarnlock.txt" }}
-            # If no exact match is found, restore partial cache
+            # If checksum is new, restore partial cache
             - v1-yarn-deps-
       - run: yarn deps
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,10 +18,8 @@ commands:
       - run:
           name: Combine package-lock.json files to single file
           command: cat yarn.lock frontend/yarn.lock > << parameters.filename >>
-      - run: tail -n 10 combined-yarnlock.txt
 jobs:
   build:
-    # Each job must declare an executor
     executor: docker-executor
     steps:
       - checkout
@@ -29,7 +27,7 @@ jobs:
       - restore_cache:
           keys:
             - v1-yarn-deps-{{ checksum "combined-yarnlock.txt" }}
-            # If no exact match is found, partial cache restore with latest
+            # If no exact match is found, restore partial cache
             - v1-yarn-deps-
       - run: yarn deps
       - save_cache:


### PR DESCRIPTION
**Description of change**
Circle CI has the ability to cache dependencies between runs of the same workflow.  See the [circle ci caching docs](https://circleci.com/docs/2.0/caching/) for more information on this feature.  In this PR, I'm adding caching here for the yarn.lock files (both frontend and backend) and the ability of to "fall back" to the most recent cache so only new/updated libraries are pulled in.

**How to test**
The way to see this in action is to check out the latest Circle CI [build for this branch](https://app.circleci.com/pipelines/github/adhocteam/Head-Start-TTADP/174/workflows/cae20c1e-91e6-48c6-982a-8e73487c9b9d). 

**Issue(s)**
* related to https://github.com/HHS/Head-Start-TTADP/issues/12

**Checklist**
<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] Code tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
