### PR TITLE
CI: Fix yarn.lock caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,8 @@ jobs:
       - run: yarn deps
       - save_cache:
           paths:
-            - combined-yarnlock.txt
+            - node_modules
+            - frontend/node_modules
           key: v1-yarn-deps-{{ checksum "combined-yarnlock.txt" }}
       - persist_to_workspace:
           root: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,16 +33,16 @@ jobs:
       - create_combined_yarnlock
       - restore_cache:
           keys:
-            # To manually bust the cache, increment the version numbers e.g. v2-yarn...
-            - v1-yarn-deps-{{ checksum "combined-yarnlock.txt" }}
+            # To manually bust the cache, increment the version e.g. v3-yarn...
+            - v2-yarn-deps-{{ checksum "combined-yarnlock.txt" }}
             # If checksum is new, restore partial cache
-            - v1-yarn-deps-
+            - v2-yarn-deps-
       - run: yarn deps
       - save_cache:
           paths:
             - node_modules
             - frontend/node_modules
-          key: v1-yarn-deps-{{ checksum "combined-yarnlock.txt" }}
+          key: v2-yarn-deps-{{ checksum "combined-yarnlock.txt" }}
       - persist_to_workspace:
           root: .
           paths:


### PR DESCRIPTION
**Description of change**
In https://github.com/adhocteam/Head-Start-TTADP/pull/21 I added caching for node modules.  However, I made a mistake when I set it up. When saving the cache I was giving the combined text file as the thing to cache, not the actual node modules. This PR fixes that.  Because cache keys were already created with the same name I needed to bust the cache by incrementing to `v2`.

**How to test**
The way to see this in action is to check on the circle ci [build for this branch](https://app.circleci.com/pipelines/github/adhocteam/Head-Start-TTADP/178/workflows/3e8ce98d-9ebb-4893-878c-0fcc95c20c3a/jobs/467)

**Issue(s)**
Related to https://github.com/HHS/Head-Start-TTADP/issues/12

**Checklist**
<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] Code tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified