### PR TITLE
CI: Fail build if node modules need updating

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Welcome to the home of the OHS TTADP.
 What We're Building and Why
 ---------------
 
-For the latest on our product mission, goals, initiatives, and KPIs, see the [Product Planning page](https://github.com/HHS/Head-Start-TTADP/wiki/Product-Planning).  
+For the latest on our product mission, goals, initiatives, and KPIs, see the [Product Planning page](https://github.com/HHS/Head-Start-TTADP/wiki/Product-Planning).
 
 
 Getting Started
@@ -45,7 +45,8 @@ Other Commands
 | `yarn docker:lint` | Runs the linter for the frontend and backend in docker containers |
 | `yarn docker:db:migrate` | Run migrations in docker containers |
 | `yarn docker:db:migrate:undo` | Undo migrations in docker containers |
-| `yarn deps` | Install dependencies for the frontend and backend |
+| `yarn deps:local` | Install dependencies for the frontend and backend (for local development)  |
+| `yarn deps` | Install dependencies for the frontend and backend (for deployment) |
 | `yarn start` | Starts the backend and frontend |
 | `yarn server` | Starts the backend |
 | `yarn client` | Start the frontend |

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "node": "^12.18"
   },
   "scripts": {
-    "deps": "yarn install && yarn --cwd frontend install",
+    "deps:local": "yarn install && yarn --cwd frontend install",
+    "deps": "yarn install --frozen-lockfile && yarn --cwd frontend install --frozen-lockfile",
     "start": "concurrently \"yarn server\" \"yarn client\"",
     "server": "nodemon src/index.js --ignore './frontend/' --exec babel-node",
     "server:debug": "nodemon src/index.js --ignore './frontend/' --exec babel-node --inspect=0.0.0.0:9229",


### PR DESCRIPTION
**Description of change**
Fail CI/CD build if updates are needed to dependancies beyond what is in the `yarn.lock` files. The deployed environments dependancies should always match what is currently in version control. This will result in some failed builds, but I'd rather the deploy fail than introduced untested changes in deployed environments. See [docs](https://classic.yarnpkg.com/en/docs/cli/install/#toc-yarn-install-frozen-lockfile) for the `--frozen-lockfile` flag.

This will also ensure that the node modules cached by circleci will match the cache key created from the `yarn.lock` files.

**How to test**
Check out latest [build job for this branch](https://app.circleci.com/pipelines/github/adhocteam/Head-Start-TTADP/187/workflows/593622fc-d15e-4b74-8e9f-56cc00bbf383/jobs/506) 

**Issue(s)**
* related to https://github.com/HHS/Head-Start-TTADP/issues/12

**Checklist**
<!-- Add details to each completed item -->
- [n/a] Meets issue criteria
- [x] Code tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [x] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
