### PR TITLE
Make HSES auth uris configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,5 @@ POSTGRES_HOST=localhost
 AUTH_CLIENT_ID=clientId
 AUTH_CLIENT_SECRET=clientSecret
 SESSION_SECRET=secret
+AUTH_BASE=https://uat.hsesinfo.org
+REDIRECT_URI_HOST=http://localhost:8080

--- a/deployment_config/dev_vars.yml
+++ b/deployment_config/dev_vars.yml
@@ -4,3 +4,5 @@ env: dev
 instances: 1
 NODE_ENV: production
 SESSION_SECRET: ${SESSION_SECRET}
+AUTH_BASE: https://uat.hsesinfo.org
+REDIRECT_URI_HOST: https://tta-smarthub.app.cloud.gov

--- a/deployment_config/prod_vars.yml
+++ b/deployment_config/prod_vars.yml
@@ -4,3 +4,5 @@ env: prod
 instances: 2
 NODE_ENV: production
 SESSION_SECRET: ${PROD_SESSION_SECRET}
+AUTH_BASE: https://uat.hsesinfo.org
+REDIRECT_URI_HOST: https://tta-smarthub.app.cloud.gov

--- a/deployment_config/sandbox_vars.yml
+++ b/deployment_config/sandbox_vars.yml
@@ -4,3 +4,5 @@ env: sandbox
 instances: 1
 NODE_ENV: production
 SESSION_SECRET: ${SESSION_SECRET}
+AUTH_BASE: https://uat.hsesinfo.org
+REDIRECT_URI_HOST: https://tta-smarthub-sandbox.app.cloud.gov

--- a/deployment_config/staging_vars.yml
+++ b/deployment_config/staging_vars.yml
@@ -4,3 +4,5 @@ env: staging
 instances: 1
 NODE_ENV: production
 SESSION_SECRET: ${STAGING_SESSION_SECRET}
+AUTH_BASE: https://uat.hsesinfo.org
+REDIRECT_URI_HOST: https://tta-smarthub.app.cloud.gov

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ router.get(oauth2CallbackPath, async (req, res) => {
     // user will have accessToken and refreshToken
     const requestObj = user.sign({
       method: 'get',
-      url: 'https://uat.hsesinfo.org/auth/user/me',
+      url: `${process.env.AUTH_BASE}/auth/user/me`,
     });
 
     const { url } = requestObj;

--- a/src/middleware/authMiddleware.js
+++ b/src/middleware/authMiddleware.js
@@ -24,7 +24,6 @@ export const hsesAuth = new ClientOAuth2({
 
 export default async function authMiddleware(req, res, next) {
   req.session.originalUrl = req.originalUrl;
-  // console.log(`session: ${JSON.stringify(req.session)}`);
   if (!req.session.userId) {
     const uri = hsesAuth.code.getUri();
 

--- a/src/middleware/authMiddleware.js
+++ b/src/middleware/authMiddleware.js
@@ -4,9 +4,9 @@ import ClientOAuth2 from 'client-oauth2';
 export const hsesAuth = new ClientOAuth2({
   clientId: process.env.AUTH_CLIENT_ID,
   clientSecret: process.env.AUTH_CLIENT_SECRET,
-  accessTokenUri: 'https://uat.hsesinfo.org/auth/oauth/token',
-  authorizationUri: 'https://uat.hsesinfo.org/auth/oauth/authorize',
-  redirectUri: 'http://localhost:8080/oauth2-client/login/oauth2/code/',
+  accessTokenUri: `${process.env.AUTH_BASE}/auth/oauth/token`,
+  authorizationUri: `${process.env.AUTH_BASE}/auth/oauth/authorize`,
+  redirectUri: `${process.env.REDIRECT_URI_HOST}/oauth2-client/login/oauth2/code/`,
   scopes: ['user_info'],
 });
 


### PR DESCRIPTION
**Description of change**
Made the HSES auth uris configurable to work in different environments

**How to test**
Local and docker local test:
- add the following to the .env file (also shown in .envexample)
```
AUTH_BASE=https://uat.hsesinfo.org
REDIRECT_URI_HOST=http://localhost:8080
```
- start the server (`yarn server or yarn:docker:start`)
- navigate to localhost:8080
- verify that things work as before (after login we are redirected to ttasmarthub)

**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/0

**Checklist**
<!-- Add details to each completed item -->
- [x] Code tested
[-] Meets issue criteria
[-] Meets accessibility standards (WCAG 2.1 Levels A, AA)
[-] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
