### PR TITLE
CD: Add Auth callback to manifest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ parameters:
     default: "main"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
-    default: "sj-fix-env-var"
+    default: "sj-add-callback-to-manifest"
     type: string
 jobs:
   build:

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,9 @@ applications:
   instances: ((instances))
   command: yarn start
   env:
+    AUTH_BASE: ((AUTH_BASE))
     AUTH_CLIENT_ID: ((AUTH_CLIENT_ID))
     AUTH_CLIENT_SECRET: ((AUTH_CLIENT_SECRET))
-    SESSION_SECRET: ((SESSION_SECRET))
     NODE_ENV: ((NODE_ENV))
+    REDIRECT_URI_HOST: ((REDIRECT_URI_HOST))
+    SESSION_SECRET: ((SESSION_SECRET))


### PR DESCRIPTION
**Description of change**
In https://github.com/adhocteam/Head-Start-TTADP/pull/31 we made the auth uris configurable.  And in https://github.com/adhocteam/Head-Start-TTADP/pull/32 we cleaned up the route values.  Here we're adding those auth uri variables to the deployment manifest so that the running application receives those environment variables.

**How to test**

- check that most recent deployment on this branch passed https://app.circleci.com/pipelines/github/adhocteam/Head-Start-TTADP?branch=sj-add-callback-to-manifest
- check that variables are passed into sandbox application instance https://dashboard.fr.cloud.gov/applications/2oBn9LBurIXUNpfmtZCQTCHnxUM/f0bc4bc7-4a3c-4253-a184-4f3581e31b16/variables
- check that sandbox application is running https://tta-smarthub-sandbox.app.cloud.gov/. After login, the redirect should work now!
<img width="426" alt="Screen Shot 2020-09-23 at 5 22 36 PM" src="https://user-images.githubusercontent.com/9893700/94075799-7152f900-fdc1-11ea-974e-4d36dd763bb1.png">
----------------------------------------------------------------------------------------

**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/47

**Checklist**
<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] Code tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
