### PR TITLE
Region dropdown shows central office. Remove unnecessary key prop

### DIFF
--- a/frontend/src/components/RegionDropdown.js
+++ b/frontend/src/components/RegionDropdown.js
@@ -18,7 +18,7 @@ function RegionDropdown({
           <option key={number} value={number}>{`${number} - ${description}`}</option>
         ))}
         {includeCentralOffice
-        && <option name="central-office" value="13">Central Office</option>}
+        && <option name="central-office" value="co">Central Office</option>}
       </Dropdown>
     </>
   );

--- a/frontend/src/components/RegionDropdown.js
+++ b/frontend/src/components/RegionDropdown.js
@@ -7,7 +7,7 @@ import {
 import { REGIONS } from '../Constants';
 
 function RegionDropdown({
-  id, name, value, onChange,
+  id, name, value, onChange, includeCentralOffice,
 }) {
   return (
     <>
@@ -17,6 +17,8 @@ function RegionDropdown({
         {REGIONS.map(({ number, name: description }) => (
           <option key={number} value={number}>{`${number} - ${description}`}</option>
         ))}
+        {includeCentralOffice
+        && <option name="central-office" value="13">Central Office</option>}
       </Dropdown>
     </>
   );
@@ -27,10 +29,12 @@ RegionDropdown.propTypes = {
   name: PropTypes.string.isRequired,
   value: PropTypes.string,
   onChange: PropTypes.func.isRequired,
+  includeCentralOffice: PropTypes.bool,
 };
 
 RegionDropdown.defaultProps = {
   value: 'default',
+  includeCentralOffice: false,
 };
 
 export default RegionDropdown;

--- a/frontend/src/components/__tests__/JobTitleDropdown.js
+++ b/frontend/src/components/__tests__/JobTitleDropdown.js
@@ -5,7 +5,7 @@ import { render, screen } from '@testing-library/react';
 import JobTitleDropdown from '../JobTitleDropdown';
 
 describe('JobTitleDropdown', () => {
-  test('defaults to the correct option', () => {
+  test('shows "select a job title" (the default) when no value is selected', () => {
     render(<JobTitleDropdown id="id" name="name" onChange={() => {}} />);
     expect(screen.getByLabelText('Job Title').value).toBe('default');
   });

--- a/frontend/src/components/__tests__/RegionDropdown.js
+++ b/frontend/src/components/__tests__/RegionDropdown.js
@@ -5,7 +5,7 @@ import { render, screen } from '@testing-library/react';
 import RegionDropdown from '../RegionDropdown';
 
 describe('RegionalDropdown', () => {
-  test('defaults to the correct option', () => {
+  test('shows "select an option" (the default) when no value is selected', () => {
     render(<RegionDropdown id="id" name="name" onChange={() => {}} />);
     expect(screen.getByLabelText('Region').value).toBe('default');
   });
@@ -14,5 +14,15 @@ describe('RegionalDropdown', () => {
     render(<RegionDropdown id="id" name="name" onChange={() => {}} />);
     const item = screen.getByLabelText('Region').options.namedItem('default');
     expect(item.hidden).toBeTruthy();
+  });
+
+  test('does not show central office when includeCentralOffice is not specified', () => {
+    render(<RegionDropdown id="id" name="name" onChange={() => {}} />);
+    expect(screen.queryByText('Central Office')).toBeNull()
+  });
+
+  test('with prop includeCentralOffice has central office as an option', () => {
+    render(<RegionDropdown id="id" name="name" includeCentralOffice onChange={() => {}} />);
+    expect(screen.queryByText('Central Office')).toBeVisible();
   });
 });

--- a/frontend/src/components/__tests__/RegionDropdown.js
+++ b/frontend/src/components/__tests__/RegionDropdown.js
@@ -18,7 +18,7 @@ describe('RegionalDropdown', () => {
 
   test('does not show central office when includeCentralOffice is not specified', () => {
     render(<RegionDropdown id="id" name="name" onChange={() => {}} />);
-    expect(screen.queryByText('Central Office')).toBeNull()
+    expect(screen.queryByText('Central Office')).toBeNull();
   });
 
   test('with prop includeCentralOffice has central office as an option', () => {

--- a/frontend/src/pages/Admin/UserInfo.js
+++ b/frontend/src/pages/Admin/UserInfo.js
@@ -26,7 +26,7 @@ function UserInfo({ user, onUserChange }) {
       </Grid>
       <Grid row gap>
         <Grid col={6}>
-          <RegionDropdown id="user-region" name="region" value={user.region} onChange={onUserChange} />
+          <RegionDropdown id="user-region" name="region" value={user.region} onChange={onUserChange} includeCentralOffice />
         </Grid>
         <Grid col={6}>
           <JobTitleDropdown id="job-title" name="jobTitle" value={user.jobTitle} onChange={onUserChange} />

--- a/frontend/src/pages/Admin/components/CurrentPermissions.js
+++ b/frontend/src/pages/Admin/components/CurrentPermissions.js
@@ -5,7 +5,7 @@ function CurrentPermissions({ regions, scope }) {
   const regionsStr = regions.length === 1 ? 'Region' : 'Regions';
   const regionMsg = `${regionsStr} ${regions.join(', ')}`;
   return (
-    <li key={scope}>
+    <li>
       <strong>{scope}</strong>
       {': '}
       {regionMsg}

--- a/frontend/src/pages/Admin/index.js
+++ b/frontend/src/pages/Admin/index.js
@@ -37,7 +37,7 @@ const fetchedUsers = [
         scope: 'READ_WRITE_REPORTS',
       },
     ],
-    region: '1',
+    region: 'co',
   },
   {
     id: 3,


### PR DESCRIPTION
**Description of change**

Feedback from https://github.com/HHS/Head-Start-TTADP/pull/54

**How to test**

1) `yarn deps` (`yarn docker:deps`)
2) `yarn start:local` (`yarn docker:start`)
3) Browse to `localhost:3000/admin`

**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/39

**Checklist**
<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] Code tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
