### PR TITLE
Js 53 add stepper

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ parameters:
     default: "main"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
-    default: "js-fix-deployed-ui-login"
+    default: "js-53-add-stepper"
     type: string
 jobs:
   build:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,12 +10,13 @@
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-hook-form": "^6.9.1",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "react-router-prop-types": "^1.0.5",
-    "url-join": "^4.0.1",
     "react-scripts": "^3.4.3",
-    "uswds": "^2.8.1"
+    "url-join": "^4.0.1",
+    "uswds": "^2.9.0"
   },
   "engines": {
     "node": "^12.18"

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>TTA Smart Hub</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "TTA Smart Hub",
+  "name": "TTA Smart Hub",
   "icons": [
     {
       "src": "favicon.ico",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,26 @@
+.background-stripe {
+  position: absolute;
+  top: 0;
+  z-index: -1;
+  left: 0;
+  width: 100%;
+  height: 345px;
+  content: "";
+  background-color: #264a64;
+}
+
+header {
+  background-color: #f8f8f8;
+}
+body {
+  background-color: #f8f8f8;
+}
+
+.height-12 {
+  height: 6.5em;
+}
+
+.usa-legend {
+  font-size: 2.13rem;
+  font-weight: bold;
+}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -7,12 +7,12 @@ import { GridContainer } from '@trussworks/react-uswds';
 
 import { fetchUser, fetchLogout } from './fetchers/Auth';
 
+import UserContext from './UserContext';
 import Header from './components/Header';
+import Page from './pages';
 import Admin from './pages/Admin';
 import Unauthenticated from './pages/Unauthenticated';
 import Home from './pages/Home';
-import UserContext from './UserContext';
-
 import ActivityReport from './pages/ActivityReport';
 import './App.css';
 
@@ -52,9 +52,30 @@ function App() {
 
   const renderAuthenticatedRoutes = () => (
     <>
-      <Route Home path="/" component={Home} />
-      <Route path="/admin/:userId?" component={Admin} />
-      <Route path="/activity-reports" component={ActivityReport} />
+      <Route
+        path="/"
+        render={() => (
+          <Page title="TTA Smart Hub">
+            <Home />
+          </Page>
+        )}
+      />
+      <Route
+        path="/admin/:userId?"
+        render={({ match }) => (
+          <Page title="User Administration">
+            <Admin match={match} />
+          </Page>
+        )}
+      />
+      <Route
+        path="/activity-reports"
+        render={() => (
+          <Page title="Activity Reports">
+            <ActivityReport />
+          </Page>
+        )}
+      />
     </>
   );
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
-import '@trussworks/react-uswds/lib/uswds.css';
 import '@trussworks/react-uswds/lib/index.css';
+import 'uswds/dist/css/uswds.css';
+
 import { BrowserRouter, Route } from 'react-router-dom';
 import { GridContainer } from '@trussworks/react-uswds';
 
@@ -11,6 +12,9 @@ import Admin from './pages/Admin';
 import Unauthenticated from './pages/Unauthenticated';
 import Home from './pages/Home';
 import UserContext from './UserContext';
+
+import ActivityReport from './pages/ActivityReport';
+import './App.css';
 
 function App() {
   const [user, updateUser] = useState();
@@ -50,6 +54,7 @@ function App() {
     <>
       <Route Home path="/" component={Home} />
       <Route path="/admin/:userId?" component={Admin} />
+      <Route path="/activity-reports" component={ActivityReport} />
     </>
   );
 
@@ -57,6 +62,7 @@ function App() {
     <BrowserRouter>
       <UserContext.Provider value={{ user, authenticated, logout }}>
         <Header authenticated={authenticated} />
+        <div className="background-stripe" />
         <section className="usa-section">
           <GridContainer>
             {!authenticated

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import '@trussworks/react-uswds/lib/index.css';
 import 'uswds/dist/css/uswds.css';
+import '@trussworks/react-uswds/lib/index.css';
 
 import { BrowserRouter, Route } from 'react-router-dom';
 import { GridContainer } from '@trussworks/react-uswds';
@@ -53,6 +53,7 @@ function App() {
   const renderAuthenticatedRoutes = () => (
     <>
       <Route
+        exact
         path="/"
         render={() => (
           <Page title="TTA Smart Hub">

--- a/frontend/src/components/Container.js
+++ b/frontend/src/components/Container.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const classes = 'bg-white radius-md shadow-2 margin-bottom-3';
+
+function Container({ children, className, padding }) {
+  return (
+    <div className={`${classes} ${className}`}>
+      <div className={`padding-${padding}`}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+Container.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+  padding: PropTypes.number,
+};
+
+Container.defaultProps = {
+  className: '',
+  padding: 5,
+};
+
+export default Container;

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -14,6 +14,9 @@ function Header({ authenticated }) {
     <NavLink exact to="/">
       Home
     </NavLink>,
+    <NavLink to="/activity-reports">
+      Activity Reports
+    </NavLink>,
     <NavLink to="/admin">
       Admin
     </NavLink>,

--- a/frontend/src/components/Stepper/Pager.js
+++ b/frontend/src/components/Stepper/Pager.js
@@ -1,0 +1,77 @@
+/*
+  Used to page through components in a specific step. It uses onNextStep and
+  onPreviousStep to let the parent component know it has reached the start/end of it's
+  pages. It does not currently support being nested inside another <Pager />. It may
+  be possible to update it to support nesting if needed in the future, but it isn't
+  currently built with nesting in mind
+*/
+
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+
+function Pager({
+  firstStep, lastStep, pages, fromNextStep, onNextStep, onPreviousStep, data,
+}) {
+  // fromNextStep is true if we are coming from a later step (the current step is
+  // step 2 and the previous step was step 3, the user clicked the 'previous' button).
+  // If we are coming from a later step we need to show the last page in the current step.
+  const startIndex = fromNextStep ? pages.length - 1 : 0;
+  const [currentPage, updateCurrentPage] = useState(startIndex);
+  const [formData, updateData] = useState(data);
+
+  const firstPage = currentPage === 0;
+  const lastPage = currentPage === pages.length - 1;
+  // Used to disable the "previous" button if this is the first page of the first step
+  const first = firstStep && firstPage;
+  // used to show the "submit" (as opposed to "next") button if this is the last page
+  // of the last step
+  const last = lastStep && lastPage;
+
+  const onNextPage = (newData) => {
+    const newFormData = { ...formData, ...newData };
+    if (lastPage) {
+      onNextStep(newFormData);
+    } else {
+      updateData(newFormData);
+      updateCurrentPage(currentPage + 1);
+    }
+  };
+
+  const onPreviousPage = () => {
+    if (firstPage) {
+      onPreviousStep();
+    } else {
+      updateCurrentPage(currentPage - 1);
+    }
+  };
+
+  const page = pages[currentPage];
+
+  return (
+    <>
+      {page({
+        first,
+        last,
+        onNextStep: onNextPage,
+        onPreviousStep: onPreviousPage,
+        data,
+      })}
+    </>
+  );
+}
+
+Pager.propTypes = {
+  firstStep: PropTypes.bool.isRequired,
+  lastStep: PropTypes.bool.isRequired,
+  pages: PropTypes.arrayOf(PropTypes.func).isRequired,
+  fromNextStep: PropTypes.bool.isRequired,
+  onNextStep: PropTypes.func.isRequired,
+  onPreviousStep: PropTypes.func.isRequired,
+  // data is form data coming in, we won't know the shape of
+  // the data object since this component is supposed to be
+  // reuseable between multiple forms
+  // eslint-disable-next-line react/forbid-prop-types
+  data: PropTypes.object.isRequired,
+};
+
+export default Pager;

--- a/frontend/src/components/Stepper/__tests__/Pager.js
+++ b/frontend/src/components/Stepper/__tests__/Pager.js
@@ -1,0 +1,77 @@
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable react/prop-types */
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import Pager from '../Pager';
+
+const renderPager = (pages, fromNextStep, onNextStep = () => {}, onPreviousStep = () => {}) => {
+  render(
+    <Pager
+      pages={pages}
+      firstStep
+      lastStep
+      fromNextStep={fromNextStep}
+      onNextStep={onNextStep}
+      onPreviousStep={onPreviousStep}
+      data={{}}
+    />,
+  );
+};
+
+describe('Pager', () => {
+  it('starts with the last page if "fromNextStep" is true', () => {
+    const pages = [
+      () => (<div>first page</div>),
+      () => (<div>last page</div>),
+    ];
+    renderPager(pages, true);
+    expect(screen.getByText('last page')).toBeDefined();
+  });
+
+  describe('onNextPage', () => {
+    const pages = [
+      ({ onNextStep }) => (<div onClick={onNextStep}>first page</div>),
+      ({ onNextStep }) => (<div onClick={onNextStep}>last page</div>),
+    ];
+
+    it('pages forward when not on the last page', () => {
+      renderPager(pages, false);
+      const first = screen.getByText('first page');
+      fireEvent.click(first);
+      expect(screen.getByText('last page')).toBeDefined();
+    });
+
+    it('calls onNextStep if on the last page', () => {
+      const mockOnNextStep = jest.fn();
+      renderPager(pages, true, mockOnNextStep);
+      const last = screen.getByText('last page');
+      fireEvent.click(last);
+      expect(mockOnNextStep).toHaveBeenCalled();
+    });
+  });
+
+  describe('onPreviousPage', () => {
+    const pages = [
+      ({ onPreviousStep }) => (<div onClick={onPreviousStep}>first page</div>),
+      ({ onPreviousStep }) => (<div onClick={onPreviousStep}>last page</div>),
+    ];
+
+    it('pages backwards when not on the first page', () => {
+      renderPager(pages, true);
+      const last = screen.getByText('last page');
+      fireEvent.click(last);
+      expect(screen.getByText('first page')).toBeDefined();
+    });
+
+    it('calls onPreviousStep if on the first page', () => {
+      const mockOnPreviousStep = jest.fn();
+      renderPager(pages, false, () => {}, mockOnPreviousStep);
+      const first = screen.getByText('first page');
+      fireEvent.click(first);
+      expect(mockOnPreviousStep).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/components/Stepper/__tests__/index.js
+++ b/frontend/src/components/Stepper/__tests__/index.js
@@ -1,0 +1,77 @@
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable react/prop-types */
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import Stepper from '../index';
+
+// expect(screen.queryAllByRole('link').length).not.toBe(0);
+describe('Stepper', () => {
+  describe('with several steps', () => {
+    const steps = [
+      {
+        label: 'first',
+        pages: ({ onNextStep }) => (<div onClick={onNextStep}>First Page</div>),
+      },
+      {
+        label: 'second',
+        pages: ({ onNextStep, onPreviousStep }) => (
+          <>
+            <div onClick={onPreviousStep}>Second Page</div>
+            <div onClick={onNextStep}>Next</div>
+          </>
+        ),
+      },
+      {
+        label: 'third',
+        pages: [
+          () => (<div>Page 1</div>),
+          () => (<div />),
+        ],
+      },
+    ];
+
+    beforeEach(() => {
+      render(<Stepper steps={steps} onSubmit={() => {}} />);
+    });
+
+    it('displays the first page', () => {
+      expect(screen.getByText('First Page')).toBeDefined();
+    });
+
+    it('can change the step to the next step', () => {
+      const next = screen.getByText('First Page');
+      fireEvent.click(next);
+      expect(screen.getByText('Second Page')).toBeDefined();
+    });
+
+    it('can change the step to the previous step', () => {
+      const next = screen.getByText('First Page');
+      fireEvent.click(next);
+      const previous = screen.getByText('Second Page');
+      fireEvent.click(previous);
+      expect(screen.getByText('First Page')).toBeDefined();
+    });
+
+    it('uses the pager when the step has multiple pages', () => {
+      const next = screen.getByText('First Page');
+      fireEvent.click(next);
+      const toPager = screen.getByText('Next');
+      fireEvent.click(toPager);
+      expect(screen.getByText('Page 1')).toBeDefined();
+    });
+  });
+
+  describe('with a single step', () => {
+    it('nextStep submits data', () => {
+      const mockSubmit = jest.fn();
+      const steps = [{ label: 'test', pages: ({ onNextStep }) => <div onClick={onNextStep}>step</div> }];
+      render(<Stepper steps={steps} onSubmit={mockSubmit} />);
+      const step = screen.getByText('step');
+      fireEvent.click(step);
+      expect(mockSubmit).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/components/Stepper/components/Footer.js
+++ b/frontend/src/components/Stepper/components/Footer.js
@@ -1,0 +1,29 @@
+/*
+  This footer should be used with inside <Pager /> or <Stepper /> forms. I feel
+  like this class may be able to be refactored using 'render-props' for a better
+  developer experience when creating forms.
+*/
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button } from '@trussworks/react-uswds';
+
+function Footer({
+  first, last, valid, onPreviousStep,
+}) {
+  return (
+    <div>
+      <Button type="button" outline disabled={first} onClick={onPreviousStep}>Previous</Button>
+      {!last && <Button type="submit" disabled={!valid}>Next</Button>}
+      {last && <Button type="submit" disabled={!valid}>Submit</Button>}
+    </div>
+  );
+}
+
+Footer.propTypes = {
+  first: PropTypes.bool.isRequired,
+  last: PropTypes.bool.isRequired,
+  valid: PropTypes.bool.isRequired,
+  onPreviousStep: PropTypes.func.isRequired,
+};
+
+export default Footer;

--- a/frontend/src/components/Stepper/components/StepperHeader.js
+++ b/frontend/src/components/Stepper/components/StepperHeader.js
@@ -1,0 +1,32 @@
+/*
+  Stepper indicator header shows the current step label and number out
+  of the total number of steps
+*/
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const StepperHeader = ({ currentStep, totalSteps, label }) => (
+  <div className="usa-step-indicator__header">
+    <h2 className="usa-step-indicator__heading">
+      <span className="usa-step-indicator__heading-counter">
+        <span className="usa-sr-only">Step</span>
+        <span className="usa-step-indicator__current-step">{currentStep}</span>
+        <span className="usa-step-indicator__total-steps">
+          {' '}
+          of
+          {' '}
+          {totalSteps}
+        </span>
+      </span>
+      <span className="usa-step-indicator__heading-text">{label}</span>
+    </h2>
+  </div>
+);
+
+StepperHeader.propTypes = {
+  currentStep: PropTypes.number.isRequired,
+  totalSteps: PropTypes.number.isRequired,
+  label: PropTypes.string.isRequired,
+};
+
+export default StepperHeader;

--- a/frontend/src/components/Stepper/components/StepperIndicator.css
+++ b/frontend/src/components/Stepper/components/StepperIndicator.css
@@ -1,0 +1,3 @@
+.usa-step-indicator__segments li:last-child {
+  max-width: fit-content;
+}

--- a/frontend/src/components/Stepper/components/StepperIndicator.js
+++ b/frontend/src/components/Stepper/components/StepperIndicator.js
@@ -1,0 +1,46 @@
+/*
+  Our react USWDS library does not have support for the step indicator,
+  which is why those components are defined in our codebase. This component
+  represents the complete stepper navigation. It converts an array of "steps"
+  which are objects with a label and what "stepper" status the object has
+  (active vs complete vs incomplete) and converts the objects into the
+  appropriate <StepperIndicatorSegment />
+*/
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import StepperIndicatorSegment from './StepperIndicatorSegment';
+// The css in this file along with `flex-justify-center` causes the indicator to be
+// _mostly_ centered in whatever container it is inside of. flex-justify-center centers
+// the complete ordered list. The max-width css class removes most of the extra width
+// on the last element in the list. Without these CSS changes the stepper indicator
+// is too far to the left (because the last element in the list has a lot of unused
+// space). The problem is more pronounced the fewer steps there are in the stepper.
+import './StepperIndicator.css';
+
+const StepperIndicator = ({ segments }) => (
+  <div className="usa-step-indicator usa-step-indicator--counters" aria-label="progress">
+    <ol className="usa-step-indicator__segments flex-justify-center">
+      {segments.map((segment) => (
+        <StepperIndicatorSegment
+          key={segment.label}
+          label={segment.label}
+          complete={segment.complete}
+          current={segment.current}
+        />
+      ))}
+    </ol>
+  </div>
+);
+
+StepperIndicator.propTypes = {
+  segments: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      complete: PropTypes.bool.isRequired,
+      current: PropTypes.bool.isRequired,
+    }),
+  ).isRequired,
+};
+
+export default StepperIndicator;

--- a/frontend/src/components/Stepper/components/StepperIndicatorSegment.js
+++ b/frontend/src/components/Stepper/components/StepperIndicatorSegment.js
@@ -1,0 +1,37 @@
+/*
+  This component is the Number, line and label in the stepper. It should
+  be used inside a <StepperIndicator />
+*/
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const StepperIndicatorSegment = ({ label, complete, current }) => {
+  let segmentClass;
+  let screenReaderMessage;
+
+  if (complete) {
+    segmentClass = 'usa-step-indicator__segment--complete';
+    screenReaderMessage = 'completed';
+  } if (current) {
+    segmentClass = 'usa-step-indicator__segment--current';
+  } else {
+    screenReaderMessage = 'not completed';
+  }
+
+  return (
+    <li data-testid={label} className={`usa-step-indicator__segment width-fit-content  ${segmentClass || ''}`}>
+      <span className="usa-step-indicator__segment-label" aria-current={current}>
+        {label}
+        {screenReaderMessage && <span className="usa-sr-only">{screenReaderMessage}</span> }
+      </span>
+    </li>
+  );
+};
+
+StepperIndicatorSegment.propTypes = {
+  label: PropTypes.string.isRequired,
+  complete: PropTypes.bool.isRequired,
+  current: PropTypes.bool.isRequired,
+};
+
+export default StepperIndicatorSegment;

--- a/frontend/src/components/Stepper/components/__tests__/Footer.js
+++ b/frontend/src/components/Stepper/components/__tests__/Footer.js
@@ -1,0 +1,54 @@
+import '@testing-library/jest-dom';
+import { screen, render } from '@testing-library/react';
+import React from 'react';
+
+import Footer from '../Footer';
+
+describe('Footer', () => {
+  it('if first is true the previous button is disabled', () => {
+    render(<Footer first last={false} valid onPreviousStep={() => {}} />);
+    expect(screen.getByText('Previous')).toBeDisabled();
+  });
+
+  describe('if last is false', () => {
+    beforeEach(() => {
+      render(<Footer first last={false} valid onPreviousStep={() => {}} />);
+    });
+
+    it('the Next button is shown', () => {
+      const next = screen.queryByText('Next');
+      expect(next).toBeDefined();
+    });
+
+    it('the Submit button is hidden', () => {
+      expect(screen.queryByText('Submit')).toBeNull();
+    });
+  });
+
+  describe('if last is true', () => {
+    beforeEach(() => {
+      render(<Footer first={false} last valid onPreviousStep={() => {}} />);
+    });
+
+    it('the Submit button is shown', () => {
+      const submit = screen.queryByText('Submit');
+      expect(submit).toBeDefined();
+    });
+
+    it('the Next button is hidden', () => {
+      expect(screen.queryByText('Next')).toBeNull();
+    });
+  });
+
+  describe('if valid is false', () => {
+    it('the Next button is disabled', () => {
+      render(<Footer first last={false} valid={false} onPreviousStep={() => {}} />);
+      expect(screen.getByText('Next')).toBeDisabled();
+    });
+
+    it('the Submit button is disabled', () => {
+      render(<Footer first last valid={false} onPreviousStep={() => {}} />);
+      expect(screen.getByText('Submit')).toBeDisabled();
+    });
+  });
+});

--- a/frontend/src/components/Stepper/components/__tests__/StepperHeader.js
+++ b/frontend/src/components/Stepper/components/__tests__/StepperHeader.js
@@ -1,0 +1,19 @@
+import '@testing-library/jest-dom';
+import { screen, render } from '@testing-library/react';
+import React from 'react';
+
+import StepperHeader from '../StepperHeader';
+
+describe('StepperHeader', () => {
+  beforeEach(() => {
+    render(<StepperHeader currentStep={1} totalSteps={10} label="Test Step" />);
+  });
+
+  describe('displays the correct information', () => {
+    it('step', () => {
+      const heading = screen.getByRole('heading');
+      expect(heading).toHaveTextContent('1 of 10');
+      expect(heading).toHaveTextContent('Test Step');
+    });
+  });
+});

--- a/frontend/src/components/Stepper/components/__tests__/StepperIndicator.js
+++ b/frontend/src/components/Stepper/components/__tests__/StepperIndicator.js
@@ -8,7 +8,7 @@ const COMPLETE_CLASS = 'usa-step-indicator__segment--complete';
 const CURRENT_CLASS = 'usa-step-indicator__segment--current';
 
 describe('StepperIndicator', () => {
-  const steps = [
+  const segments = [
     {
       label: 'complete',
       complete: true,
@@ -27,7 +27,7 @@ describe('StepperIndicator', () => {
   ];
 
   beforeEach(() => {
-    render(<StepperIndicator steps={steps} />);
+    render(<StepperIndicator segments={segments} />);
   });
 
   it('properly sets the complete class on complete items', () => {

--- a/frontend/src/components/Stepper/components/__tests__/StepperIndicator.js
+++ b/frontend/src/components/Stepper/components/__tests__/StepperIndicator.js
@@ -1,0 +1,48 @@
+import '@testing-library/jest-dom';
+import { screen, render } from '@testing-library/react';
+import React from 'react';
+
+import StepperIndicator from '../StepperIndicator';
+
+const COMPLETE_CLASS = 'usa-step-indicator__segment--complete';
+const CURRENT_CLASS = 'usa-step-indicator__segment--current';
+
+describe('StepperIndicator', () => {
+  const steps = [
+    {
+      label: 'complete',
+      complete: true,
+      current: false,
+    },
+    {
+      label: 'current',
+      complete: false,
+      current: true,
+    },
+    {
+      label: 'unvisited',
+      complete: false,
+      current: false,
+    },
+  ];
+
+  beforeEach(() => {
+    render(<StepperIndicator steps={steps} />);
+  });
+
+  it('properly sets the complete class on complete items', () => {
+    const complete = screen.getByTestId('complete');
+    expect(complete).toHaveClass(COMPLETE_CLASS);
+  });
+
+  it('properly sets the current class on current items', () => {
+    const current = screen.getByTestId('current');
+    expect(current).toHaveClass(CURRENT_CLASS);
+  });
+
+  it('does not set classes on incomplete items', () => {
+    const unvisited = screen.getByTestId('unvisited');
+    expect(unvisited).not.toHaveClass(COMPLETE_CLASS);
+    expect(unvisited).not.toHaveClass(COMPLETE_CLASS);
+  });
+});

--- a/frontend/src/components/Stepper/index.js
+++ b/frontend/src/components/Stepper/index.js
@@ -59,7 +59,7 @@ function Stepper({ steps, onSubmit }) {
 
   useEffect(() => {
     const stepperSegments = steps.map((step) => defaultSegment(step.label));
-    stepperSegments[currentStep] = { ...segments[currentStep], current: true };
+    stepperSegments[currentStep] = { ...stepperSegments[currentStep], current: true };
 
     updateSegments(stepperSegments);
   }, [steps]);

--- a/frontend/src/components/Stepper/index.js
+++ b/frontend/src/components/Stepper/index.js
@@ -1,0 +1,164 @@
+/*
+  This component is the stepper. It contains a stepper indicator section to show
+  where in the stepper process the user currently is. It also contains a
+  section to show the current form. It is responsible for stepping through
+  each step, gathering data to send to the parent (via `onSubmit`) once all
+  steps are complete and the user clicks "submit". The "steps" prop is an
+  array of objects with label and pages properties. Label is a string
+  and what is displayed in the stepper indicator. Pages is a single render function
+  or an array of render functions. The pages property makes use of a technique
+  called 'render-props' (https://reactjs.org/docs/render-props.html). This allows
+  the stepper component to inject props into the component as well as having
+  props injected into the form component where defined. All forms should use
+  the `react-hook-form` library and stepper footer.
+
+  Each step in the form can have multiple "pages". This is accomplished by
+  using the <Pager /> component. If pages is an array the <Pager /> Component
+  will be used. If not the pages function will be used without the pager.
+*/
+
+import React, { useState, useEffect } from 'react';
+import { Grid } from '@trussworks/react-uswds';
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+
+import Pager from './Pager';
+import Container from '../Container';
+import StepperIndicator from './components/StepperIndicator';
+import StepperHeader from './components/StepperHeader';
+import { usePrevious } from '../../hooks';
+
+const defaultSegment = (label) => (
+  {
+    current: false,
+    complete: false,
+    label,
+  }
+);
+
+export const getUpdatedSegments = (segments, previousStep, nextStep, complete) => {
+  const prevSegment = {
+    ...segments[previousStep], current: false, complete,
+  };
+
+  const nextSegment = {
+    ...segments[nextStep], current: true, complete: false,
+  };
+
+  const updatedSegments = [...segments];
+  updatedSegments[previousStep] = prevSegment;
+  updatedSegments[nextStep] = nextSegment;
+
+  return updatedSegments;
+};
+
+function Stepper({ steps, onSubmit }) {
+  const [currentStep, updateCurrentStep] = useState(0);
+  const [formData, updateFormData] = useState({});
+  const [segments, updateSegments] = useState([]);
+
+  useEffect(() => {
+    const stepperSegments = steps.map((step) => defaultSegment(step.label));
+    stepperSegments[currentStep] = { ...segments[currentStep], current: true };
+
+    updateSegments(stepperSegments);
+  }, [steps]);
+
+  const totalSteps = steps.length;
+  const firstStep = currentStep === 0;
+  const lastStep = currentStep === totalSteps - 1;
+
+  const onNextStep = (data) => {
+    if (lastStep) {
+      onSubmit(formData);
+      return;
+    }
+
+    const updatedSegments = getUpdatedSegments(
+      segments,
+      currentStep,
+      currentStep + 1,
+      true,
+    );
+
+    updateSegments(updatedSegments);
+    updateFormData({ ...formData, ...data });
+    updateCurrentStep(currentStep + 1);
+  };
+
+  const onPreviousStep = () => {
+    if (firstStep) {
+      return;
+    }
+
+    const updatedStepperSegments = getUpdatedSegments(
+      segments,
+      currentStep,
+      currentStep - 1,
+      false,
+    );
+
+    updateSegments(updatedStepperSegments);
+    updateCurrentStep(currentStep - 1);
+  };
+
+  const previousStep = usePrevious(currentStep);
+  const fromNextStep = previousStep > currentStep;
+  const pages = _.get(steps[currentStep], 'pages');
+  const label = _.get(steps[currentStep], 'label');
+  const usePager = Array.isArray(pages);
+
+  return (
+    <div>
+      <Grid row gap>
+        <Grid col={12}>
+          <Container className="height-12" padding={2}>
+            <StepperIndicator segments={segments} />
+          </Container>
+        </Grid>
+        <Grid col={12}>
+          <Container className="height-viewport">
+            <StepperHeader
+              currentStep={currentStep + 1}
+              totalSteps={totalSteps}
+              label={label}
+            />
+            {usePager
+            && (
+            <Pager
+              firstStep={firstStep}
+              lastStep={lastStep}
+              data={formData}
+              onNextStep={onNextStep}
+              onPreviousStep={onPreviousStep}
+              fromNextStep={fromNextStep}
+              pages={pages}
+            />
+            )}
+            {!usePager
+            && (
+              pages({
+                first: firstStep, last: lastStep, data: formData, onNextStep, onPreviousStep,
+              })
+            )}
+          </Container>
+        </Grid>
+      </Grid>
+    </div>
+  );
+}
+
+Stepper.propTypes = {
+  steps: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      pages: PropTypes.oneOfType([
+        PropTypes.func,
+        PropTypes.arrayOf(PropTypes.func.isRequired),
+      ]),
+    }),
+  ).isRequired,
+  onSubmit: PropTypes.func.isRequired,
+};
+
+export default Stepper;

--- a/frontend/src/components/Stepper/index.js
+++ b/frontend/src/components/Stepper/index.js
@@ -17,7 +17,7 @@
   will be used. If not the pages function will be used without the pager.
 */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Grid } from '@trussworks/react-uswds';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
@@ -55,14 +55,10 @@ export const getUpdatedSegments = (segments, previousStep, nextStep, complete) =
 function Stepper({ steps, onSubmit }) {
   const [currentStep, updateCurrentStep] = useState(0);
   const [formData, updateFormData] = useState({});
-  const [segments, updateSegments] = useState([]);
 
-  useEffect(() => {
-    const stepperSegments = steps.map((step) => defaultSegment(step.label));
-    stepperSegments[currentStep] = { ...stepperSegments[currentStep], current: true };
-
-    updateSegments(stepperSegments);
-  }, [steps]);
+  const stepperSegments = steps.map((step) => defaultSegment(step.label));
+  stepperSegments[currentStep] = { ...stepperSegments[currentStep], current: true };
+  const [segments, updateSegments] = useState(stepperSegments);
 
   const totalSteps = steps.length;
   const firstStep = currentStep === 0;

--- a/frontend/src/components/Stepper/index.js
+++ b/frontend/src/components/Stepper/index.js
@@ -70,16 +70,9 @@ function Stepper({ steps, onSubmit }) {
       return;
     }
 
-    const updatedSegments = getUpdatedSegments(
-      segments,
-      currentStep,
-      currentStep + 1,
-      true,
-    );
-
-    updateSegments(updatedSegments);
+    updateSegments(() => getUpdatedSegments(segments, currentStep, currentStep + 1, true));
     updateFormData({ ...formData, ...data });
-    updateCurrentStep(currentStep + 1);
+    updateCurrentStep((current) => current + 1);
   };
 
   const onPreviousStep = () => {
@@ -87,15 +80,8 @@ function Stepper({ steps, onSubmit }) {
       return;
     }
 
-    const updatedStepperSegments = getUpdatedSegments(
-      segments,
-      currentStep,
-      currentStep - 1,
-      false,
-    );
-
-    updateSegments(updatedStepperSegments);
-    updateCurrentStep(currentStep - 1);
+    updateSegments(() => getUpdatedSegments(segments, currentStep, currentStep - 1, false));
+    updateCurrentStep((current) => current - 1);
   };
 
   const previousStep = usePrevious(currentStep);

--- a/frontend/src/hooks.js
+++ b/frontend/src/hooks.js
@@ -1,0 +1,13 @@
+// Disable prefer default export, this file will probably accumulate additional
+// custom hooks at some point
+/* eslint-disable import/prefer-default-export */
+// See https://reactjs.org/docs/hooks-faq.html#how-to-get-the-previous-props-or-state
+import { useEffect, useRef } from 'react';
+
+export function usePrevious(value) {
+  const ref = useRef();
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+}

--- a/frontend/src/pages/ActivityReport/index.css
+++ b/frontend/src/pages/ActivityReport/index.css
@@ -1,0 +1,13 @@
+.new-activity-report {
+  font-family: Merriweather;
+  font-size: 50px;
+  font-weight: bold;
+  font-stretch: normal;
+  font-style: normal;
+  line-height: normal;
+  letter-spacing: normal;
+  color: #ffffff;
+  margin-bottom: 40px;
+  margin-top: 40px;
+}
+

--- a/frontend/src/pages/ActivityReport/index.js
+++ b/frontend/src/pages/ActivityReport/index.js
@@ -1,0 +1,103 @@
+/*
+  This component is showing how to use the stepper. It will be
+  updated in the future with actual activity report form
+  components
+*/
+import React, { useState } from 'react';
+import { Button } from '@trussworks/react-uswds';
+
+import Container from '../../components/Container';
+import Stepper from '../../components/Stepper';
+import Step from './step';
+import './index.css';
+
+// Note how we receive most props from the caller of this
+// method (the stepper or pager).
+function renderStep(props, label) {
+  const {
+    first, last, onNextStep, onPreviousStep, data,
+  } = props;
+  return (
+    <Step
+      first={first}
+      last={last}
+      onNextStep={onNextStep}
+      onPreviousStep={onPreviousStep}
+      data={data}
+      label={label}
+    />
+  );
+}
+
+const steps = [
+  {
+    label: 'Activity Summary',
+    // This is the 'render-prop' used by the stepper/pager. The pager
+    // doesn't know how to pass the 'label' prop, but we know what the
+    // label should be at this point.
+    pages: (props) => (
+      renderStep(props, 'Activity Summary')
+    ),
+  },
+  {
+    // Show how the stepper supports multiple pages in a single
+    // step
+    label: 'Participants',
+    pages: [
+      (props) => (
+        renderStep(props, 'Participants - Page 1')
+      ),
+      (props) => (
+        renderStep(props, 'Participants - Page 2')
+      ),
+    ],
+  },
+  {
+    label: 'Goals & Objectives',
+    pages: (props) => (
+      renderStep(props, 'Goals & Objectives')
+    ),
+  },
+  {
+    label: 'Next Steps',
+    pages: (props) => (
+      renderStep(props, 'Next Steps')
+    ),
+  },
+  {
+    label: 'Review & Submit',
+    pages: (props) => (
+      renderStep(props, 'Review & Submit')
+    ),
+  },
+];
+
+function ActivityReport() {
+  const [data, updateData] = useState();
+  const onSubmit = (formData) => {
+    updateData(formData);
+  };
+
+  return (
+    <>
+      <div className="new-activity-report">New activity report for Region 14</div>
+      {data && (
+        <Container>
+          <h1>
+            Data submitted!
+          </h1>
+          <Button onClick={() => { updateData(); }}>
+            Reset Form
+          </Button>
+        </Container>
+      )}
+      {!data && (
+        <>
+          <Stepper steps={steps} onSubmit={onSubmit} />
+        </>
+      )}
+    </>
+  );
+}
+
+export default ActivityReport;

--- a/frontend/src/pages/ActivityReport/step.js
+++ b/frontend/src/pages/ActivityReport/step.js
@@ -1,0 +1,43 @@
+/*
+  Simple example "form" with no fields to be used by the stepper/pager
+*/
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useForm } from 'react-hook-form';
+import { Form } from '@trussworks/react-uswds';
+
+import Footer from '../../components/Stepper/components/Footer';
+
+const Step = ({
+  first, last, onNextStep, onPreviousStep, data, label,
+}) => {
+  const {
+    handleSubmit, formState,
+  } = useForm({
+    mode: 'onTouched',
+    defaultValues: data,
+  });
+
+  return (
+    <Form onSubmit={handleSubmit(onNextStep)} large>
+      <h1>{label}</h1>
+      <Footer
+        first={first}
+        last={last}
+        valid={formState.isValid}
+        onPreviousStep={onPreviousStep}
+      />
+    </Form>
+  );
+};
+
+Step.propTypes = {
+  first: PropTypes.bool.isRequired,
+  last: PropTypes.bool.isRequired,
+  onNextStep: PropTypes.func.isRequired,
+  onPreviousStep: PropTypes.func.isRequired,
+  data: PropTypes.shape({}).isRequired,
+  label: PropTypes.string.isRequired,
+};
+
+export default Step;

--- a/frontend/src/pages/Admin/index.js
+++ b/frontend/src/pages/Admin/index.js
@@ -7,6 +7,7 @@ import {
 } from '@trussworks/react-uswds';
 import UserSection from './UserSection';
 import NavLink from '../../components/NavLink';
+import Container from '../../components/Container';
 
 // Fake return from an API
 const fetchedUsers = [
@@ -181,7 +182,7 @@ function Admin(props) {
   });
 
   return (
-    <>
+    <Container>
       <h1 className="text-center">User Administration</h1>
       <Grid row gap>
         <Grid col={4}>
@@ -205,7 +206,7 @@ function Admin(props) {
           )}
         </Grid>
       </Grid>
-    </>
+    </Container>
   );
 }
 

--- a/frontend/src/pages/Home/index.js
+++ b/frontend/src/pages/Home/index.js
@@ -3,6 +3,7 @@ import { Switch, Route } from 'react-router-dom';
 import { Button } from '@trussworks/react-uswds';
 
 import UserContext from '../../UserContext';
+import Container from '../../components/Container';
 
 function Home() {
   return (
@@ -10,7 +11,7 @@ function Home() {
       <Route exact path="/">
         <UserContext.Consumer>
           {({ user, logout }) => (
-            <>
+            <Container>
               <h1>
                 Welcome to the TTA Smart Hub
                 {' '}
@@ -19,7 +20,7 @@ function Home() {
               <Button onClick={logout}>
                 Logout
               </Button>
-            </>
+            </Container>
           )}
         </UserContext.Consumer>
       </Route>

--- a/frontend/src/pages/Unauthenticated/index.js
+++ b/frontend/src/pages/Unauthenticated/index.js
@@ -3,10 +3,11 @@ import PropTypes from 'prop-types';
 import {
   Link, Alert,
 } from '@trussworks/react-uswds';
+import Container from '../../components/Container';
 
 function Unauthenticated({ loggedOut }) {
   return (
-    <>
+    <Container>
       {loggedOut
       && (
       <Alert type="success" heading="Logout Successful">
@@ -22,7 +23,7 @@ function Unauthenticated({ loggedOut }) {
       <Link className="usa-button" variant="unstyled" href="api/login">
         HSES Login
       </Link>
-    </>
+    </Container>
   );
 }
 

--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -1,0 +1,10 @@
+import { useEffect } from 'react';
+
+const Page = (props) => {
+  useEffect(() => {
+    document.title = props.title || '';
+  }, [props.title]);
+  return props.children;
+};
+
+export default Page;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -9111,6 +9111,11 @@ react-error-overlay@^6.0.7:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.7.tgz#1dcfb459ab671d53f660a991513cb2f0a0553108"
   integrity sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA==
 
+react-hook-form@^6.9.1:
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.9.1.tgz#f99240ba740e529b3a84b01efb89a86321e100ec"
+  integrity sha512-ldzb73Au9NPdb/IfO9bOYS2S+41qjZdXRr5Z6wnSw1UPpLR0uKjPFn5x+SnVOtD/kUpC4vznXi6PYT7C567CQw==
+
 react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -10855,10 +10860,24 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
-uswds@^2.7.0, uswds@^2.8.1:
+uswds@^2.7.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/uswds/-/uswds-2.8.1.tgz#937505ad8f7be4c131e6d4e01d0128cf0995a49c"
   integrity sha512-x7RkaVFVuRxptsuUZka6Mc+wUUL98keorOUFVxrBIgd3KV18upuF5V7osm9sN/q6bGvwh2zJyfONETLUU8Eemg==
+  dependencies:
+    classlist-polyfill "^1.0.3"
+    del "^5.1.0"
+    domready "^1.0.8"
+    elem-dataset "^2.0.0"
+    lodash.debounce "^4.0.7"
+    object-assign "^4.1.1"
+    receptor "^1.0.0"
+    resolve-id-refs "^0.1.0"
+
+uswds@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/uswds/-/uswds-2.9.0.tgz#002089d74582960099b0ee836f89f043cdf6d0bc"
+  integrity sha512-5IMVgMCUUlgWVFrB7Wf1qTvv5L3oDDlSsAgvJ02+/sV2uh4JzO9YPm3493RTaMuHTc+feRCuYyEIloXsEQY0Pg==
   dependencies:
     classlist-polyfill "^1.0.3"
     del "^5.1.0"


### PR DESCRIPTION
**Description of change**

Add the stepper.

The stepper accepts any number of "steps" defined as a label an one or more pages. The stepper can go through these steps in order, backwards or forwards. If a step has multiple pages The pager is used to go through each individual page. The main difference between a page and step are steps are displayed in a "navigation" section at the top of the stepper, pages do not show up in the stepper "navigation". A simple use of the stepper is added in the `ActivityReport` component. This component will soon be updated/removed once work begins on the actual activity report.

Some exploratory work has been done with how to use the stepper with actual form input, which is why `react-hook-form` is used by the stepper and the `ActivityReport` component. There is opportunity to make building forms easier using the stepper and `react-hook-forms` that will be explored once we implement a real form.

**How to test**

Locally:

1. `yarn docker:deps`
2. Browse to `localhost:3000` and login
3. Click the `Activity Reports` button
4. Click through the report

Sandbox:

1. Browse to https://tta-smarthub-sandbox.app.cloud.gov/ and login
2. Click the `Activity Reports` button
3. Click through the report

**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/53

**Checklist**
<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] Code tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [x] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
