### PR TITLE
CI: Dynamic Security Scan feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Linting, unit tests and test coverage analysis are all run automatically on each
 to the Ad Hoc fork of HHS/Head-Start-TTADP repo and the HHS/Head-Start-TTADP repo. In
 the Ad Hoc repository, merges to the main branch are blocked if the continuous
 integration (CI) tests do not pass. The continuous integration pipeline is configured via CircleCi.
-The bulk of CI configurations can be found in this repo's [.circleci/config.yml](.circleci/config.yml) file. For more information on the security audit and scan tools used in the continuous integration pipeline see [ADR 0008](docs/adr/0008-security-scans.md).
+The bulk of CI configurations can be found in this repo's [.circleci/config.yml](.circleci/config.yml) file. For more information on the security audit and scan tools used in the continuous integration pipeline see [ADR 0009](docs/adr/0009-security-scans.md).
 
 Deployment
 ----------

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -17,6 +17,7 @@ services:
       POSTGRES_USERNAME: postgres
       POSTGRES_PASSWORD: secretpass
       POSTGRES_DB: ttasmarthub
+      SESSION_SECRET: notasecret
     volumes:
       - ".:/app:rw"
   db:

--- a/docs/adr/0009-security-scans.md
+++ b/docs/adr/0009-security-scans.md
@@ -1,6 +1,6 @@
-# 8. Security Scans
+# 9. Security Scans
 
-Date: 2020-10-09
+Date: 2020-10-15
 
 ## Status
 


### PR DESCRIPTION
**Description of change**
Addresses feedback from review of https://github.com/HHS/Head-Start-TTADP/pull/94
- renumbered ADR to 9
- added `SESSION_SECRET` var to backend server env in docker test

**How to test**
check server logs in docker container
- open circle ci https://app.circleci.com/pipelines/github/adhocteam/Head-Start-TTADP?branch=sj-owasp-feedback
- click onto pipeline run, select `dynamic_security_scan` job, then select "Rerun job with SSH"
- Open new ssh session for pipeline job
- After OWASP zap runs, `docker ps` to get id of the container that's running the backend server
- `docker container logs < container id >` to see server logs and check for errors

**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/11

**Checklist**
<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] Code tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [x] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
