### PR TITLE
Remove placeholder and unnecessary fragment

### DIFF
--- a/frontend/src/components/MultiSelect.js
+++ b/frontend/src/components/MultiSelect.js
@@ -42,35 +42,33 @@ const styles = {
 };
 
 function MultiSelect({
-  label, name, options, disabled, control, placeholder, required,
+  label, name, options, disabled, control, required,
 }) {
   return (
-    <>
-      <Label>
-        {label}
-        <Controller
-          render={({ onChange, value }) => (
-            <Select
-              id={name}
-              value={value}
-              onChange={onChange}
-              styles={styles}
-              components={{ DropdownIndicator }}
-              options={options}
-              isDisabled={disabled}
-              placeholder={placeholder}
-              isMulti
-            />
-          )}
-          control={control}
-          defaultValue=""
-          rules={{
-            required,
-          }}
-          name={name}
-        />
-      </Label>
-    </>
+    <Label>
+      {label}
+      <Controller
+        render={({ onChange, value }) => (
+          <Select
+            id={name}
+            value={value}
+            onChange={onChange}
+            styles={styles}
+            components={{ DropdownIndicator }}
+            options={options}
+            isDisabled={disabled}
+            placeholder=""
+            isMulti
+          />
+        )}
+        control={control}
+        defaultValue=""
+        rules={{
+          required,
+        }}
+        name={name}
+      />
+    </Label>
   );
 }
 
@@ -83,7 +81,6 @@ MultiSelect.propTypes = {
       label: PropTypes.string.isRequired,
     }),
   ).isRequired,
-  placeholder: PropTypes.string.isRequired,
   // eslint-disable-next-line react/forbid-prop-types
   control: PropTypes.object.isRequired,
   disabled: PropTypes.bool,

--- a/frontend/src/pages/ActivityReport/SectionOne.js
+++ b/frontend/src/pages/ActivityReport/SectionOne.js
@@ -83,7 +83,6 @@ const PageOne = ({
             label="Who was this activity for?"
             disabled={disableParticipant}
             control={control}
-            placeholder={`Select a ${nonGranteeSelected ? 'Non-grantee...' : 'Grantee...'}`}
             options={
               participants.map((participant) => ({ value: participant, label: participant }))
             }
@@ -94,7 +93,6 @@ const PageOne = ({
             name="other-users"
             label="Other Specialist(s) involved in this activity (optional)"
             control={control}
-            placeholder="Select another Specialist..."
             required={false}
             options={
               otherUsers.map((user) => ({ value: user, label: user }))
@@ -129,7 +127,6 @@ const PageOne = ({
             name="reason"
             label="What was the reason for this activity?"
             control={control}
-            placeholder="Select a reason..."
             options={
               reasons.map((reason) => ({ value: reason, label: reason }))
             }

--- a/frontend/src/pages/ActivityReport/SectionThree.js
+++ b/frontend/src/pages/ActivityReport/SectionThree.js
@@ -82,7 +82,6 @@ const PageThree = ({
             name="participants"
             label="Grantee participant(s) involved"
             control={control}
-            placeholder="Select a participant..."
             options={
               participants.map((participant) => ({ value: participant, label: participant }))
             }

--- a/frontend/src/pages/ActivityReport/SectionTwo.js
+++ b/frontend/src/pages/ActivityReport/SectionTwo.js
@@ -29,7 +29,6 @@ const PageTwo = ({
           name="topics"
           label="Choose all topics covered"
           control={control}
-          placeholder="Select a topic..."
           options={
             topics.map((topic) => ({ value: topic, label: topic }))
           }

--- a/frontend/src/pages/ActivityReport/__tests__/index.js
+++ b/frontend/src/pages/ActivityReport/__tests__/index.js
@@ -6,7 +6,6 @@ import {
 } from '@testing-library/react';
 import moment from 'moment';
 
-import { withText } from '../../../testHelpers';
 import ActivityReport from '../index';
 
 const formData = () => ({

--- a/frontend/src/pages/ActivityReport/__tests__/index.js
+++ b/frontend/src/pages/ActivityReport/__tests__/index.js
@@ -25,38 +25,31 @@ const formData = () => ({
   topics: 'first',
 });
 
-describe('ActivityReport', () => {
-  describe('grantee select', () => {
-    describe('changes the participant selection to', () => {
-      it('Grantee', async () => {
-        render(<ActivityReport />);
-        const information = await waitFor(() => screen.getByRole('group', { name: 'General Information' }));
-        const grantee = within(information).getByLabelText('Grantee');
-        fireEvent.click(grantee);
-        expect(await waitFor(() => screen.getByText(withText('Select a Grantee...')))).toBeVisible();
-      });
+const enableParticipantSelect = async (target) => {
+  render(<ActivityReport />);
 
-      it('Non-grantee', async () => {
-        render(<ActivityReport />);
-        const information = await waitFor(() => screen.getByRole('group', { name: 'General Information' }));
-        const nonGrantee = within(information).getByLabelText('Non-Grantee');
-        fireEvent.click(nonGrantee);
-        expect(await waitFor(() => screen.getByText(withText('Select a Non-grantee...')))).toBeVisible();
+  const enabled = await screen.getByRole('textbox', { name: 'Who was this activity for?' });
+  expect(enabled).toBeDisabled();
+
+  const information = await waitFor(() => screen.getByRole('group', { name: 'General Information' }));
+  const grantee = within(information).getByLabelText(target);
+  fireEvent.click(grantee);
+};
+
+describe('ActivityReport', () => {
+  describe('participant selection is enabled', () => {
+    it('when grantee is selected', async () => {
+      await act(async () => {
+        await enableParticipantSelect('Grantee');
+        const disabled = await screen.getByRole('textbox', { name: 'Who was this activity for?' });
+        expect(disabled).not.toBeDisabled();
       });
     });
 
-    it('enables the participant selection', async () => {
+    it('when non-grantee is selected', async () => {
       await act(async () => {
-        render(<ActivityReport />);
-
-        const enabled = await screen.getByRole('textbox', { name: 'Who was this activity for? Select a Grantee...' });
-        expect(enabled).toBeDisabled();
-
-        const information = await waitFor(() => screen.getByRole('group', { name: 'General Information' }));
-        const grantee = within(information).getByLabelText('Grantee');
-        fireEvent.click(grantee);
-
-        const disabled = await screen.getByRole('textbox', { name: 'Who was this activity for? Select a Grantee...' });
+        await enableParticipantSelect('Non-Grantee');
+        const disabled = await screen.getByRole('textbox', { name: 'Who was this activity for?' });
         expect(disabled).not.toBeDisabled();
       });
     });


### PR DESCRIPTION
**Description of change**
Remove unnecessary placeholder and react fragment (empty `<>`, `</>` tags) from the multiselect component

**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/128

**Checklist**
<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] Code tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
