### PR TITLE
Terraform: Init sandbox env

### DIFF
--- a/terraform/sandbox/main.tf
+++ b/terraform/sandbox/main.tf
@@ -1,0 +1,54 @@
+###
+# Terraform settings and backend
+###
+
+terraform {
+  required_providers {
+    cloudfoundry = {
+      source  = "cloudfoundry-community/cloudfoundry"
+      version = "0.12.6"
+    }
+  }
+
+  backend "s3" {
+    bucket  = "cg-77510827-41f7-4b13-aa6b-c292afe85b25"
+    key     = "terraform.tfstate.sandbox"
+    encrypt = true
+    region  = "us-gov-west-1"
+  }
+}
+
+provider "cloudfoundry" {
+  api_url      = var.cf_api_url
+  user         = var.cf_user
+  password     = var.cf_password
+  app_logs_max = 30
+}
+
+provider "aws" {
+  region  = var.aws_region
+  version = "~> 3.11.0"
+}
+
+###
+# Target space/org
+###
+
+data "cloudfoundry_space" "space" {
+  org_name = var.cf_org_name
+  name     = var.cf_space_name
+}
+
+###
+# RDS instance
+###
+
+data "cloudfoundry_service" "rds" {
+  name = "aws-rds"
+}
+
+resource "cloudfoundry_service_instance" "database" {
+  name         = "ttahub-${var.env}"
+  space        = data.cloudfoundry_space.space.id
+  service_plan = data.cloudfoundry_service.rds.service_plans["micro-psql"]
+}

--- a/terraform/sandbox/variables.tf
+++ b/terraform/sandbox/variables.tf
@@ -1,0 +1,46 @@
+# Secrets to be provided via environment variables or
+# in `secrets.auto.tfvars.` When provided via environment
+# variables, the names must be prefixed with `TF_VAR_`
+# Ex. `TF_VAR_cf_user="foobarbaz"`
+# For more information on generating values secret variables
+# see terraform/README.md.
+
+variable "aws_region" {
+  type        = string
+  description = "region output by cloud foundry service-key command"
+  default     = "us-gov-west-1"
+}
+
+variable "cf_api_url" {
+  type        = string
+  description = "cloud.gov api url"
+  default     = "https://api.fr.cloud.gov"
+}
+
+variable "cf_org_name" {
+  type        = string
+  description = "cloud.gov organization name"
+  default     = "hhs-acf-ohs-tta"
+}
+
+variable "cf_password" {
+  type        = string
+  description = "secret; cloud.gov deployer account password"
+}
+
+variable "cf_space_name" {
+  type        = string
+  description = "cloud.gov space name"
+  default     = "ttahub-sandbox"
+}
+
+variable "cf_user" {
+  type        = string
+  description = "secret; cloud.gov deployer account user"
+}
+
+variable "env" {
+  type        = string
+  description = "deployment environment in shortened form (dev, staging, prod)"
+  default     = "sandbox"
+}


### PR DESCRIPTION
**Description of change**
Create terraform sandbox env. This moved up in our queue because I need a way to test out service bindings in pursuit of https://github.com/HHS/Head-Start-TTADP/issues/149, and service binding are created on application deployments.  Our method for testing application deployment changes has been to use the sandbox application deployments. Therefore, I need the sandbox terraform env to exist.

**How to test**
See tf plan in comments

**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/112

**Checklist**
<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] Code tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] Documentation updated - Documentation for terraform is pretty robust, I didn't add anything new
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
