### PR TITLE
CD: Bind RDS instance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ parameters:
     default: "main"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
-    default: "js-128-add-multiselect-component"
+    default: "sj-bind-rds"
     type: string
 jobs:
   build:

--- a/deployment_config/dev_vars.yml
+++ b/deployment_config/dev_vars.yml
@@ -6,5 +6,6 @@ instances: 1
 NODE_ENV: production
 # This env variable should go away soon in favor of TTA_SMART_HUB_URI
 REDIRECT_URI_HOST: https://tta-smarthub-dev.app.cloud.gov
-TTA_SMART_HUB_URI: https://tta-smarthub-dev.app.cloud.gov
+RDS_INSTANCE: ttahub-dev
 SESSION_SECRET: ((SESSION_SECRET))
+TTA_SMART_HUB_URI: https://tta-smarthub-dev.app.cloud.gov

--- a/deployment_config/dev_vars.yml
+++ b/deployment_config/dev_vars.yml
@@ -6,6 +6,6 @@ instances: 1
 NODE_ENV: production
 # This env variable should go away soon in favor of TTA_SMART_HUB_URI
 REDIRECT_URI_HOST: https://tta-smarthub-dev.app.cloud.gov
-RDS_INSTANCE: ttahub-dev
+rds_instance: ttahub-dev
 SESSION_SECRET: ((SESSION_SECRET))
 TTA_SMART_HUB_URI: https://tta-smarthub-dev.app.cloud.gov

--- a/deployment_config/prod_vars.yml
+++ b/deployment_config/prod_vars.yml
@@ -6,5 +6,6 @@ instances: 2
 NODE_ENV: production
 # This env variable should go away soon in favor of TTA_SMART_HUB_URI
 REDIRECT_URI_HOST: https://tta-smarthub-prod.app.cloud.gov
-TTA_SMART_HUB_URI: https://tta-smarthub-prod.app.cloud.gov
+RDS_INSTANCE: ttahub-prod
 SESSION_SECRET: ((SESSION_SECRET))
+TTA_SMART_HUB_URI: https://tta-smarthub-prod.app.cloud.gov

--- a/deployment_config/prod_vars.yml
+++ b/deployment_config/prod_vars.yml
@@ -6,6 +6,6 @@ instances: 2
 NODE_ENV: production
 # This env variable should go away soon in favor of TTA_SMART_HUB_URI
 REDIRECT_URI_HOST: https://tta-smarthub-prod.app.cloud.gov
-RDS_INSTANCE: ttahub-prod
+rds_instance: ttahub-prod
 SESSION_SECRET: ((SESSION_SECRET))
 TTA_SMART_HUB_URI: https://tta-smarthub-prod.app.cloud.gov

--- a/deployment_config/sandbox_vars.yml
+++ b/deployment_config/sandbox_vars.yml
@@ -6,5 +6,6 @@ instances: 1
 NODE_ENV: production
 # This env variable should go away soon in favor of TTA_SMART_HUB_URI
 REDIRECT_URI_HOST: https://tta-smarthub-sandbox.app.cloud.gov
+RDS_INSTANCE: ttahub-sandbox
 TTA_SMART_HUB_URI: https://tta-smarthub-sandbox.app.cloud.gov
 SESSION_SECRET: ((SESSION_SECRET))

--- a/deployment_config/sandbox_vars.yml
+++ b/deployment_config/sandbox_vars.yml
@@ -6,6 +6,6 @@ instances: 1
 NODE_ENV: production
 # This env variable should go away soon in favor of TTA_SMART_HUB_URI
 REDIRECT_URI_HOST: https://tta-smarthub-sandbox.app.cloud.gov
-RDS_INSTANCE: ttahub-sandbox
+rds_instance: ttahub-sandbox
 SESSION_SECRET: ((SESSION_SECRET))
 TTA_SMART_HUB_URI: https://tta-smarthub-sandbox.app.cloud.gov

--- a/deployment_config/sandbox_vars.yml
+++ b/deployment_config/sandbox_vars.yml
@@ -7,5 +7,5 @@ NODE_ENV: production
 # This env variable should go away soon in favor of TTA_SMART_HUB_URI
 REDIRECT_URI_HOST: https://tta-smarthub-sandbox.app.cloud.gov
 RDS_INSTANCE: ttahub-sandbox
-TTA_SMART_HUB_URI: https://tta-smarthub-sandbox.app.cloud.gov
 SESSION_SECRET: ((SESSION_SECRET))
+TTA_SMART_HUB_URI: https://tta-smarthub-sandbox.app.cloud.gov

--- a/deployment_config/staging_vars.yml
+++ b/deployment_config/staging_vars.yml
@@ -6,6 +6,6 @@ instances: 1
 NODE_ENV: production
 # This env variable should go away soon in favor of TTA_SMART_HUB_URI
 REDIRECT_URI_HOST: https://tta-smarthub-staging.app.cloud.gov
-RDS_INSTANCE: ttahub-staging
+rds_instance: ttahub-staging
 SESSION_SECRET: ((SESSION_SECRET))
 TTA_SMART_HUB_URI: https://tta-smarthub-staging.app.cloud.gov

--- a/deployment_config/staging_vars.yml
+++ b/deployment_config/staging_vars.yml
@@ -6,5 +6,6 @@ instances: 1
 NODE_ENV: production
 # This env variable should go away soon in favor of TTA_SMART_HUB_URI
 REDIRECT_URI_HOST: https://tta-smarthub-staging.app.cloud.gov
-TTA_SMART_HUB_URI: https://tta-smarthub-staging.app.cloud.gov
+RDS_INSTANCE: ttahub-staging
 SESSION_SECRET: ((SESSION_SECRET))
+TTA_SMART_HUB_URI: https://tta-smarthub-staging.app.cloud.gov

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,16 +1,16 @@
 ---
 applications:
-- name: tta-smarthub-((env))
-  instances: ((instances))
-  command: yarn start
-  env:
-    AUTH_BASE: ((AUTH_BASE))
-    AUTH_CLIENT_ID: ((AUTH_CLIENT_ID))
-    AUTH_CLIENT_SECRET: ((AUTH_CLIENT_SECRET))
-    NODE_ENV: ((NODE_ENV))
-    # Soon to be removed in favor of TTA_SMART_HUB_URI
-    REDIRECT_URI_HOST: ((REDIRECT_URI_HOST))
-    TTA_SMART_HUB_URI: ((TTA_SMART_HUB_URI))
-    SESSION_SECRET: ((SESSION_SECRET))
-  services:
-    - (( RDS_INSTANCE ))
+  - name: tta-smarthub-((env))
+    instances: ((instances))
+    command: yarn start
+    env:
+      AUTH_BASE: ((AUTH_BASE))
+      AUTH_CLIENT_ID: ((AUTH_CLIENT_ID))
+      AUTH_CLIENT_SECRET: ((AUTH_CLIENT_SECRET))
+      NODE_ENV: ((NODE_ENV))
+      # Soon to be removed in favor of TTA_SMART_HUB_URI
+      REDIRECT_URI_HOST: ((REDIRECT_URI_HOST))
+      TTA_SMART_HUB_URI: ((TTA_SMART_HUB_URI))
+      SESSION_SECRET: ((SESSION_SECRET))
+    services:
+      - ((rds_instance))

--- a/manifest.yml
+++ b/manifest.yml
@@ -12,3 +12,5 @@ applications:
     REDIRECT_URI_HOST: ((REDIRECT_URI_HOST))
     TTA_SMART_HUB_URI: ((TTA_SMART_HUB_URI))
     SESSION_SECRET: ((SESSION_SECRET))
+  services:
+   - (( RDS_INSTANCE ))

--- a/manifest.yml
+++ b/manifest.yml
@@ -13,4 +13,4 @@ applications:
     TTA_SMART_HUB_URI: ((TTA_SMART_HUB_URI))
     SESSION_SECRET: ((SESSION_SECRET))
   services:
-   - (( RDS_INSTANCE ))
+  - (( RDS_INSTANCE ))

--- a/manifest.yml
+++ b/manifest.yml
@@ -13,4 +13,4 @@ applications:
     TTA_SMART_HUB_URI: ((TTA_SMART_HUB_URI))
     SESSION_SECRET: ((SESSION_SECRET))
   services:
-  - (( RDS_INSTANCE ))
+    - (( RDS_INSTANCE ))

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -143,13 +143,18 @@ _Tip: You run terraform files from the directory in which they are stored. For e
     ```bash
     terraform apply
     ```
+1. **Bind the infrastructure to the application**
+
+    CloudFoundry/cloud.gov requires that some "services" (e.g. AWS infrastructure) be "bound" to the application instance. S3, Redis, and Elasticsearch are all services that require this "binding" step. See the [cloud.gov documentation][cloudgov-bind] for more direction on this. Also, check out [PR#71][PR#71] for an example of how this was done for the RDS instances.
 
 <!-- Links -->
 
 [aws-config]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-config
 [aws-install]: https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html
+[cloudgov-bind]: https://cloud.gov/docs/deployment/managed-services/#bind-the-service-instance
 [cloudgov-deployer]: https://cloud.gov/docs/services/cloud-gov-service-account/
 [cloudgov-service-keys]: https://cloud.gov/docs/services/s3/#interacting-with-your-s3-bucket-from-outside-cloudgov
 [cf-install]: https://docs.cloudfoundry.org/cf-cli/install-go-cli.html
+[PR#71]: https://github.com/adhocteam/Head-Start-TTADP/pull/71
 [tf]: https://www.terraform.io/downloads.html
 [tf-vars]: https://www.terraform.io/docs/configuration/variables.html#variable-definitions-tfvars-files


### PR DESCRIPTION
**Description of change**
For cloudfoundry service instances (i.e. aws infrastructure) to be available to application instances there needs to be a service binding. Service bindings are dictated within the application deployment manifest. See cloud.gov docs for [more on this](https://cloud.gov/docs/deployment/managed-services/#bind-the-service-instance). This PR introduces service bindings for the rds instances.

**How to test**
I deployed to sandbox as a test. You can see the new service binding for the sandbox rds db in the "services" section for the sandbox application. (NOT the overall "services" menu, the one specific to the application that is being bound.) https://dashboard.fr.cloud.gov/applications/2oBn9LBurIXUNpfmtZCQTCHnxUM/08d4c228-67c6-47e1-ac9a-bb030c880160/services

**Issue(s)**
Not ticketed work, but should have been part of https://github.com/HHS/Head-Start-TTADP/issues/23

**Checklist**
<!-- Add details to each completed item -->
- [n/a] Meets issue criteria
- [x] Code tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [x] Documentation updated **_- Added more information to terraform readme_**
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
