### PR TITLE
Navigator feedback

### DIFF
--- a/cucumber/features/activityReport.feature
+++ b/cucumber/features/activityReport.feature
@@ -4,4 +4,4 @@ Feature: TTA Smarthub Activity Report
         And I am on the activity reports page
         Then I see "New activity report for Region 14" message
         When I select "Non-Grantee"
-        Then I see "QRIS System" as an option in the "Grantee name(s)" multiselect
+        Then I see "QRIS System" as an option in the "Non-grantee name(s)" multiselect

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -94,7 +94,7 @@ function App() {
 
   return (
     <>
-      <Helmet titleTemplate="TTA Smart Hub - %s" defaultTitle="TTA Smart Hub">
+      <Helmet titleTemplate="%s - TTA Smart Hub" defaultTitle="TTA Smart Hub">
         <meta charSet="utf-8" />
       </Helmet>
       <BrowserRouter>

--- a/frontend/src/components/Navigator/__tests__/index.js
+++ b/frontend/src/components/Navigator/__tests__/index.js
@@ -61,4 +61,12 @@ describe('Navigator', () => {
     userEvent.click(screen.getByRole('button', { name: 'Continue' }));
     await waitFor(() => expect(onSubmit).toHaveBeenCalled());
   });
+
+  it('changes navigator state to complete when "continuing"', async () => {
+    renderNavigator();
+    userEvent.click(screen.getByRole('button', { name: 'Continue' }));
+    await screen.findByTestId('second');
+    const navItem = await screen.findByText('first page');
+    await waitFor(() => expect(within(navItem.nextSibling).getByText('Complete')).toBeVisible());
+  });
 });

--- a/frontend/src/components/Navigator/components/Form.js
+++ b/frontend/src/components/Navigator/components/Form.js
@@ -22,10 +22,13 @@ function Form({
   */
   const getValuesRef = React.useRef(null);
 
-  useEffect(() => () => {
-    if (getValuesRef.current) {
-      saveForm(getValuesRef.current());
-    }
+  useEffect(() => {
+    const onUnmount = () => {
+      if (getValuesRef.current) {
+        saveForm(getValuesRef.current());
+      }
+    };
+    return onUnmount;
   }, [saveForm]);
 
   const hookForm = useForm({

--- a/frontend/src/components/Navigator/components/SideNav.css
+++ b/frontend/src/components/Navigator/components/SideNav.css
@@ -31,7 +31,7 @@
 
 .smart-hub--tag-not-started {
   background-color: #eceef1;
-  color: #21272d99;
+  color: #21272dc1;
 }
 
 .smart-hub--tag-in-progress {
@@ -40,7 +40,7 @@
 }
 
 .smart-hub--tag-complete {
-  background-color: #dcf0e3;
+  background-color: #e6faedb0;
   color: #467e5a;
 }
 

--- a/frontend/src/pages/ActivityReport/Pages/ActivitySummary.js
+++ b/frontend/src/pages/ActivityReport/Pages/ActivitySummary.js
@@ -71,6 +71,7 @@ const ActivitySummary = ({
   const nonGranteeSelected = participantSelection === 'non-grantee';
   const participants = nonGranteeSelected ? nonGrantees : grantees;
   const previousParticipantSelection = useRef(participantSelection);
+  const participantLabel = nonGranteeSelected ? 'Non-grantee name(s)' : 'Grantee name(s)';
 
   useEffect(() => {
     if (previousParticipantSelection.current !== participantSelection) {
@@ -121,7 +122,7 @@ const ActivitySummary = ({
         <div className="smart-hub--form-section">
           <MultiSelect
             name="grantees"
-            label="Grantee name(s)"
+            label={participantLabel}
             disabled={disableParticipant}
             control={control}
             options={

--- a/frontend/src/pages/ActivityReport/index.js
+++ b/frontend/src/pages/ActivityReport/index.js
@@ -106,7 +106,7 @@ function ActivityReport({ initialData }) {
 
   return (
     <>
-      <Helmet titleTemplate="TTA Smart Hub - Activity Report - %s" defaultTitle="TTA Smart Hub - Activity Report" />
+      <Helmet titleTemplate="%s - Activity Report - TTA Smart Hub" defaultTitle="TTA Smart Hub - Activity Report" />
       <h1 className="new-activity-report">New activity report for Region 14</h1>
       {submitted
         && (


### PR DESCRIPTION
**Description of change**
Address feedback from https://github.com/HHS/Head-Start-TTADP/pull/190

**How to test**

1) Pull down code and start server
2) Go to activity report page

* Selecting gratnee vs non-grantee changes the label name for "grantee name(s)"
* Color contrast for the side nave page state has been increased
* Page title is most specific to least specific

**Notes**

It might be worth it to get https://github.com/HHS/Head-Start-TTADP/issues/159 finished soon to prevent accessibility issues sooner.

**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/140

**Checklist**
<!-- Add details to each completed item -->
- [n/a] Meets issue criteria
- [x] Code tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
