### PR TITLE
Add delay to axe scan to allow page to load

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": "12.19.0"
   },
   "scripts": {
-    "axe:ci": "axe http://localhost:3000, http://localhost:3000/activity-reports, http://localhost:3000/admin --dir ./reports/ --chromedriver-path=\"node_modules/chromedriver/bin/chromedriver\"",
+    "axe:ci": "axe --exit --load-delay 1000 http://localhost:3000, http://localhost:3000/activity-reports, http://localhost:3000/admin --dir ./reports/ --chromedriver-path=\"node_modules/chromedriver/bin/chromedriver\"",
     "build": "./node_modules/.bin/babel src -d ./build/server  && ./node_modules/.bin/babel config -d build/config",
     "deps:local": "yarn install && yarn --cwd frontend install",
     "deps": "yarn install --frozen-lockfile && yarn --cwd frontend install --frozen-lockfile",


### PR DESCRIPTION
**Description of change**
Axe scans the page right after load. In the admin page there is a fake delay to simulate loading data from the API. This delay causes axe to run against the half loaded page. Added a delay between fetching of the page and the axe run to allow the page to fully load. See screenshots below.

With no delay:
![screenshot](https://user-images.githubusercontent.com/6631790/101936773-97a95900-3ba6-11eb-80b4-5fd135fc2106.png)

With a second delay:
![screenshot2](https://user-images.githubusercontent.com/6631790/101936844-b1e33700-3ba6-11eb-96fc-c733a52d00e8.png)

**How to test**
 * Verify the build passed and the `accessibility_scan` [section has no errors](https://app.circleci.com/pipelines/github/adhocteam/Head-Start-TTADP/734/workflows/f0e4b075-afe9-4741-9a44-16bf377f392a/jobs/3344)

**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/159

**Checklist**
<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [n/a] Code tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
