### PR TITLE
CD: Sync seed/migrate execution order

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,8 +137,8 @@ parameters:
     description: "Name of github branch that will deploy to dev"
     default: "main"
     type: string
-  sandbox_git_branch:  # change to feature branch to test deployment
-    default: "sj-fix-seed-order"
+  sandbox_git_branch:  # change to feature branch to deploy to sandbox
+    default: "js-52-assign-permissions-backend"
     type: string
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,21 +104,6 @@ commands:
               --var POSTGRES_PASSWORD=${<< parameters.postgres_password >>} \
               --var POSTGRES_USERNAME=${<< parameters.postgres_username >>} \
               --var SESSION_SECRET=${<< parameters.session_secret >>}
-  migrate_and_seed_db:
-    description: "Migrate and seed database. Should only be used with
-      sandbox and dev environments. Staging and prod should not contain
-      seed data."
-    parameters:
-      app_name:
-        description: "Name of Cloud Foundry cloud.gov application; must match
-          application name specified in manifest"
-        type: string
-    steps:
-      - run:
-          name: Migrate and seed database
-          command: |
-            cf run-task << parameters.app_name >> \
-            "yarn db:migrate:prod && yarn db:seed:prod"
 parameters:
   cg_org:
     description: "Cloud Foundry cloud.gov organization name"
@@ -359,9 +344,7 @@ jobs:
                 name: Return database to neutral
                 command: |
                   cf run-task tta-smarthub-sandbox \
-                  "yarn db:seed:undo:prod && yarn db:migrate:undo:prod"
-            - migrate_and_seed_db:
-                app_name: tta-smarthub-sandbox
+                  "yarn db:seed:undo:prod && yarn db:migrate:undo:prod && yarn db:migrate:prod && yarn db:seed:prod"
       - when:  # dev
           condition:
             and:
@@ -385,9 +368,7 @@ jobs:
             - run:
                 name: Undo database seeding
                 command: |
-                  cf run-task tta-smarthub-dev "yarn db:seed:undo:prod"
-            - migrate_and_seed_db:
-                app_name: tta-smarthub-dev
+                  cf run-task tta-smarthub-dev "yarn db:seed:undo:prod && yarn db:migrate:prod && yarn db:seed:prod"
       - when:  # staging
           condition:
             and:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,8 +117,8 @@ commands:
       - run:
           name: Migrate and seed database
           command: |
-            cf run-task << parameters.app_name >> "yarn db:migrate:prod"
-            cf run-task << parameters.app_name >> "yarn db:seed:prod"
+            cf run-task << parameters.app_name >> \
+            "yarn db:migrate:prod && yarn db:seed:prod"
 parameters:
   cg_org:
     description: "Cloud Foundry cloud.gov organization name"
@@ -358,8 +358,8 @@ jobs:
             - run:
                 name: Return database to neutral
                 command: |
-                  cf run-task tta-smarthub-sandbox "yarn db:seed:undo:prod"
-                  cf run-task tta-smarthub-sandbox "yarn db:migrate:undo:prod"
+                  cf run-task tta-smarthub-sandbox \
+                  "yarn db:seed:undo:prod && yarn db:migrate:undo:prod"
             - migrate_and_seed_db:
                 app_name: tta-smarthub-sandbox
       - when:  # dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,7 +341,7 @@ jobs:
                 postgres_username: SANDBOX_POSTGRES_USERNAME
                 session_secret: SANDBOX_SESSION_SECRET
             - run:
-                name: Return database to neutral
+                name: Return database to neutral, then migrate and seed
                 command: |
                   cf run-task tta-smarthub-sandbox \
                   "yarn db:seed:undo:prod && yarn db:migrate:undo:prod && yarn db:migrate:prod && yarn db:seed:prod"
@@ -366,7 +366,7 @@ jobs:
                 postgres_username: DEV_POSTGRES_USERNAME
                 session_secret: DEV_SESSION_SECRET
             - run:
-                name: Undo database seeding
+                name: Undo database seeding, then migrate and seed
                 command: |
                   cf run-task tta-smarthub-dev "yarn db:seed:undo:prod && yarn db:migrate:prod && yarn db:seed:prod"
       - when:  # staging

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -385,9 +385,9 @@ jobs:
             - run:
                 name: Undo database seeding
                 command: |
-                  cf run-task tta-smarthub-sandbox "yarn db:seed:undo:prod"
+                  cf run-task tta-smarthub-dev "yarn db:seed:undo:prod"
             - migrate_and_seed_db:
-                app_name: tta-smarthub-sandbox
+                app_name: tta-smarthub-dev
       - when:  # staging
           condition:
             and:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ parameters:
     default: "main"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
-    default: "js-52-assign-permissions-backend"
+    default: "sj-fix-seed-order"
     type: string
 jobs:
   build:


### PR DESCRIPTION
**Description of change**
In https://github.com/adhocteam/Head-Start-TTADP/pull/94 I was banking on tasks being put in a synchronous queue for execution. This proved to not be how cf handles task execution. As evidenced on the merge to the feature branch, the seed task failed because migration was not run first.  This PR puts the migration and seed commands in a single task to ensure correct execution order.

**How to test**
after merging this PR to the feature branch check the sandbox log stream, you should see all the db tasks run successfully (undo seed, undo migrate, migrate, seed). I verified the database transformations worked on my last deploy to sandbox.


**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/52

**Checklist**
<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] Code tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [x] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
