### PR TITLE
OAuth callback finds user from DB

### DIFF
--- a/src/migrations/20210105154127-users-home-region-allow-null.js
+++ b/src/migrations/20210105154127-users-home-region-allow-null.js
@@ -1,0 +1,15 @@
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.changeColumn('Users', 'homeRegionId', {
+      type: Sequelize.INTEGER,
+      allowNull: true,
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.changeColumn('Users', 'homeRegionId', {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+    });
+  },
+};

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -21,7 +21,7 @@ const roles = [
 export default (sequelize, DataTypes) => {
   class User extends Model {
     static associate(models) {
-      User.belongsTo(models.Region, { foreignKey: 'homeRegionId', as: 'homeRegion' });
+      User.belongsTo(models.Region, { foreignKey: { name: 'homeRegionId', allowNull: true }, as: 'homeRegion' });
       User.belongsToMany(models.Scope, {
         through: models.Permission, foreignKey: 'userId', as: 'scopes', timestamps: false,
       });
@@ -36,6 +36,10 @@ export default (sequelize, DataTypes) => {
       comment: null,
       primaryKey: true,
       autoIncrement: true,
+    },
+    homeRegionId: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
     },
     hsesUserId: {
       type: DataTypes.STRING,


### PR DESCRIPTION
**Description of change**

Previously the user session user was hard-coded to a specific id. Now `findOrCreateUser` is used which means if the user from HSES isn't in our DB we create that user (using the user's email and hsesId).

**How to test**

1) Run migrations
2) Make sure `skipAuth` is set to false
3) Start the server
4) Log in (`localhost:3000`)

**Notes**

Addresses feedback from https://github.com/HHS/Head-Start-TTADP/pull/242#pullrequestreview-561392037

**Checklist**
<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] Code tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
