### PR TITLE
Update user auto inc in seeder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,7 +261,7 @@ jobs:
           command: yarn db:seed:ci
       - run:
           name: Start server
-          command: BYPASS_AUTH=true CUCUMBER_USER_ID=5 yarn start:ci
+          command: BYPASS_AUTH=true CUCUMBER_USER_ID=1 yarn start:ci
           background: true
       - run:
           name: Run axe

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ parameters:
     default: "main"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
-    default: "js-135-review-page-no-saving"
+    default: "js-fix-user-autoinc"
     type: string
 jobs:
   build_and_lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,7 +261,7 @@ jobs:
           command: yarn db:seed:ci
       - run:
           name: Start server
-          command: BYPASS_AUTH=true CUCUMBER_USER_ID=1 yarn start:ci
+          command: BYPASS_AUTH=true CUCUMBER_USER_ID=5 yarn start:ci
           background: true
       - run:
           name: Run axe

--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@ TTA_SMART_HUB_URI=http://localhost:3000
 AUTH_BASE=https://uat.hsesinfo.org
 # This env variable should go away soon in favor of TTA_SMART_HUB_URI
 REDIRECT_URI_HOST=http://localhost:8080
-CUCUMBER_USER_ID=999999;
+CUCUMBER_USER_ID=5;
 # NEW_RELIC_LICENSE_KEY can be omitted in local development
 NEW_RELIC_LICENSE_KEY=secret_key
 # Set to false to require user to go through auth flow, never true in production envs

--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@ TTA_SMART_HUB_URI=http://localhost:3000
 AUTH_BASE=https://uat.hsesinfo.org
 # This env variable should go away soon in favor of TTA_SMART_HUB_URI
 REDIRECT_URI_HOST=http://localhost:8080
-CUCUMBER_USER_ID=5;
+CUCUMBER_USER_ID=1;
 # NEW_RELIC_LICENSE_KEY can be omitted in local development
 NEW_RELIC_LICENSE_KEY=secret_key
 # Set to false to require user to go through auth flow, never true in production envs

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "clean": "rm -rf coverage reports frontend/coverage frontend/reports frontend/build",
     "docs:serve": "npx redoc-cli serve -p 5000 docs/openapi/index.yaml",
     "cucumber": "./node_modules/.bin/cucumber-js --publish ./cucumber/features/*.feature -f json:./reports/cucumber_report.json && node ./cucumber/index.js",
-    "cucumber:ci": "cross-env TTA_SMART_HUB_URI=http://localhost:3000 CUCUMBER_USER_ID=999999 yarn cucumber",
+    "cucumber:ci": "cross-env TTA_SMART_HUB_URI=http://localhost:3000 CUCUMBER_USER_ID=5 yarn cucumber",
     "db:migrate": "node_modules/.bin/sequelize db:migrate",
     "db:migrate:ci": "cross-env POSTGRES_USERNAME=postgres POSTGRES_DB=ttasmarthub node_modules/.bin/sequelize db:migrate",
     "db:migrate:prod": "node_modules/.bin/sequelize db:migrate --options-path .production.sequelizerc",

--- a/src/seeders/20201124160449-users.js
+++ b/src/seeders/20201124160449-users.js
@@ -89,7 +89,7 @@ const users = [
     homeRegionId: 3,
   },
   {
-    id: 999999,
+    id: 5,
     email: 'cucumber@hogwarts.com',
     role: 'Grants Specialist',
     name: 'Cucumber User',
@@ -101,6 +101,7 @@ const users = [
 module.exports = {
   up: async (queryInterface) => {
     await queryInterface.bulkInsert('Users', users, {});
+    await queryInterface.sequelize.query('ALTER SEQUENCE "Users_id_seq" RESTART WITH 10;');
     await queryInterface.bulkInsert('Permissions', permissions, {});
   },
 


### PR DESCRIPTION
**Description of change**

Creating user records with an explicit `id` did not increment the `Users` `id` sequence. The seeder now resets the auto inc to 10 after adding records.

I checked permissions for the same issue and the sequence was set properly.

**How to test**

Login to sandbox

**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/245

**Checklist**
<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] Code tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
