### PR TITLE
Drop attachment enum type

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ parameters:
     default: "main"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
-    default: "js-135-submit-report"
+    default: "js-drop-attachment-enum"
     type: string
 jobs:
   build_and_lint:

--- a/src/migrations/20210121192644-add-attachment-type-to-files.js
+++ b/src/migrations/20210121192644-add-attachment-type-to-files.js
@@ -9,6 +9,10 @@ module.exports = {
   },
 
   down: async (queryInterface) => {
-    await queryInterface.removeColumn('Files', 'attachmentType');
+    queryInterface.sequelize.transaction(async (t) => {
+      const query = 'DROP TYPE public."enum_Files_attachmentType";';
+      await queryInterface.removeColumn('Files', 'attachmentType', { transaction: t });
+      await queryInterface.sequelize.query(query, { transaction: t });
+    });
   },
 };


### PR DESCRIPTION
**Description of change**
The file attachment migration now drops the attachment type enum when undoing the migration. Not removing the enum type causes migrations to fail in sandbox.

**How to test**
Verify the migrations run successfully in circleci
