### PR TITLE
Lock user access

### DIFF
--- a/frontend/src/Constants.js
+++ b/frontend/src/Constants.js
@@ -1,4 +1,5 @@
 export const SCOPE_IDS = {
+  SITE_ACCESS: 1,
   ADMIN: 2,
   READ_WRITE_ACTIVITY_REPORTS: 3,
   READ_ACTIVITY_REPORTS: 4,
@@ -21,6 +22,10 @@ export const REGIONAL_SCOPES = {
 };
 
 export const GLOBAL_SCOPES = {
+  [SCOPE_IDS.SITE_ACCESS]: {
+    name: 'SITE_ACCESS',
+    description: 'User can login and view the TTAHUB site',
+  },
   [SCOPE_IDS.ADMIN]: {
     name: 'ADMIN',
     description: 'User can view the admin panel and change user permissions (including their own)',

--- a/frontend/src/__tests__/App.js
+++ b/frontend/src/__tests__/App.js
@@ -41,4 +41,15 @@ describe('App', () => {
       expect(await screen.findByText('HSES Login')).toBeVisible();
     });
   });
+
+  describe('when user is locked', () => {
+    beforeEach(() => {
+      fetchMock.get(userUrl, 403);
+      render(<App />);
+    });
+
+    it('displays the login button for now. in the future this should show the "request permissions" UI', async () => {
+      expect(await screen.findByText('HSES Login')).toBeVisible();
+    });
+  });
 });

--- a/src/middleware/userAdminAccessMiddleware.js
+++ b/src/middleware/userAdminAccessMiddleware.js
@@ -16,7 +16,7 @@ import handleErrors from '../lib/apiErrorHandler';
 export default async function userAdminAccessMiddleware(req, res, next) {
   try {
     const { userId } = req.session;
-    if ((await validateUserAuthForAdmin(req))) {
+    if ((await validateUserAuthForAdmin(userId))) {
       auditLogger.info(`User ${userId} successfully checked ADMIN access`);
     } else {
       auditLogger.error(`User ${userId} attempted to access an ADMIN route without permission`);

--- a/src/routes/files/handlers.test.js
+++ b/src/routes/files/handlers.test.js
@@ -16,18 +16,23 @@ const ORIGINAL_ENV = process.env;
 jest.mock('../../lib/s3Uploader');
 
 const mockUser = {
-  id: 200,
+  id: process.env.CURRENT_USER_ID,
   homeRegionId: 1,
   permissions: [
     {
-      userId: 200,
+      userId: process.env.CURRENT_USER_ID,
       regionId: 5,
       scopeId: SCOPES.READ_WRITE_REPORTS,
     },
     {
-      userId: 200,
+      userId: process.env.CURRENT_USER_ID,
       regionId: 6,
       scopeId: SCOPES.READ_WRITE_REPORTS,
+    },
+    {
+      userId: process.env.CURRENT_USER_ID,
+      regionId: 14,
+      scopeId: SCOPES.SITE_ACCESS,
     },
   ],
 };

--- a/src/seeders/20201124160449-users.js
+++ b/src/seeders/20201124160449-users.js
@@ -1,19 +1,23 @@
-const SCOPES = {
-  SITE_ACCESS: 1,
-  ADMIN: 2,
-  READ_WRITE_REPORTS: 3,
-  READ_REPORTS: 4,
-  APPROVE_REPORTS: 5,
-};
-
-const {
-  ADMIN, READ_WRITE_REPORTS, READ_REPORTS, APPROVE_REPORTS,
-} = SCOPES;
+const SITE_ACCESS = 1;
+const ADMIN = 2;
+const READ_WRITE_REPORTS = 3;
+const READ_REPORTS = 4;
+const APPROVE_REPORTS = 5;
 
 const permissions = [
   {
     userId: 1,
+    scopeId: SITE_ACCESS,
+    regionId: 14,
+  },
+  {
+    userId: 1,
     scopeId: ADMIN,
+    regionId: 14,
+  },
+  {
+    userId: 3,
+    scopeId: SITE_ACCESS,
     regionId: 14,
   },
   {
@@ -35,6 +39,11 @@ const permissions = [
     userId: 3,
     regionId: 3,
     scopeId: READ_WRITE_REPORTS,
+  },
+  {
+    userId: 4,
+    scopeId: SITE_ACCESS,
+    regionId: 14,
   },
   {
     userId: 4,
@@ -53,13 +62,28 @@ const permissions = [
   },
   {
     userId: 5,
+    scopeId: SITE_ACCESS,
+    regionId: 14,
+  },
+  {
+    userId: 5,
     regionId: 1,
     scopeId: READ_WRITE_REPORTS,
   },
   {
     userId: 6,
+    scopeId: SITE_ACCESS,
+    regionId: 14,
+  },
+  {
+    userId: 6,
     regionId: 14,
     scopeId: ADMIN,
+  },
+  {
+    userId: 7,
+    scopeId: SITE_ACCESS,
+    regionId: 14,
   },
   {
     userId: 7,

--- a/src/tools/bootstrapAdmin.js
+++ b/src/tools/bootstrapAdmin.js
@@ -2,7 +2,7 @@ import { User, Permission } from '../models';
 import { auditLogger } from '../logger';
 import SCOPES from '../middleware/scopeConstants';
 
-const { ADMIN } = SCOPES;
+const { SITE_ACCESS, ADMIN } = SCOPES;
 
 export const ADMIN_EMAIL = 'ryan.ahearn@gsa.gov';
 
@@ -12,17 +12,28 @@ const bootstrapAdmin = async () => {
     throw new Error(`User ${ADMIN_EMAIL} could not be found to bootstrap admin`);
   }
 
-  const [permission, created] = await Permission.findOrCreate({
+  const [access, accessCreated] = await Permission.findOrCreate({
+    where: {
+      userId: user.id,
+      scopeId: SITE_ACCESS,
+      regionId: 14,
+    },
+  });
+  if (accessCreated) {
+    auditLogger.info(`Granting SITE_ACCESS to ${ADMIN_EMAIL}`);
+  }
+
+  const [admin, adminCreated] = await Permission.findOrCreate({
     where: {
       userId: user.id,
       scopeId: ADMIN,
       regionId: 14,
     },
   });
-  if (created) {
-    auditLogger.warn(`Setting ${ADMIN_EMAIL} as an ADMIN`);
+  if (adminCreated) {
+    auditLogger.warn(`Granting ADMIN to ${ADMIN_EMAIL}`);
   }
-  return permission;
+  return [admin, access];
 };
 
 export default bootstrapAdmin;


### PR DESCRIPTION
**Description of change**

Enforces `SITE_ACCESS` permissions as part of `authMiddleware`. This will address [IA-04 part e](https://nvd.nist.gov/800-53/Rev4/control/IA-4) and allow us to temporarily disable logins without having to fully rebuild the user's permissions.

**How to test**

seeded user 2 doesn't have SITE_ACCESS by default, so attempting to login as them with BYPASS_AUTH should result in a 403 response to /api/user

All other users should be able to login and use the app. The Admin UI includes SITE_ACCESS as a global permission to enable and disable logins.

**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/271

**Checklist**
<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] Code tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [x] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
