### PR TITLE
fix review page

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/reviewItem.js
+++ b/frontend/src/pages/ActivityReport/Pages/reviewItem.js
@@ -68,6 +68,9 @@ const Item = ({ label, value, path }) => {
   if (!Array.isArray(value)) {
     values = [value];
   }
+  if (label === 'Other Resources' || label === 'Attachments') {
+    values = values.map((v) => v.originalFileName);
+  }
 
   if (path) {
     values = values.map((v) => _.get(v, path));

--- a/frontend/src/pages/ActivityReport/Pages/reviewItem.js
+++ b/frontend/src/pages/ActivityReport/Pages/reviewItem.js
@@ -68,9 +68,6 @@ const Item = ({ label, value, path }) => {
   if (!Array.isArray(value)) {
     values = [value];
   }
-  if (label === 'Other Resources' || label === 'Attachments') {
-    values = values.map((v) => v.originalFileName);
-  }
 
   if (path) {
     values = values.map((v) => _.get(v, path));

--- a/frontend/src/pages/ActivityReport/Pages/topicsResources.js
+++ b/frontend/src/pages/ActivityReport/Pages/topicsResources.js
@@ -97,14 +97,14 @@ const sections = [
     anchor: 'resources',
     items: [
       { label: 'Resources used', name: 'resourcesUsed' },
-      { label: 'Other resources', name: 'otherResources', path: 'name' },
+      { label: 'Other resources', name: 'otherResources', path: 'originalFileName' },
     ],
   },
   {
     title: 'Attachments',
     anchor: 'attachments',
     items: [
-      { label: 'Attachments', name: 'attachments' },
+      { label: 'Attachments', name: 'attachments', path: 'originalFileName' },
     ],
   },
 ];

--- a/src/routes/files/handlers.js
+++ b/src/routes/files/handlers.js
@@ -17,12 +17,7 @@ const logContext = {
 };
 
 export const createFileMetaData = async (
-  originalFileName,
-  s3FileName,
-  reportId,
-  attachmentType,
-  fileSize,
-) => {
+  originalFileName, s3FileName, reportId, attachmentType, fileSize) => {
   const newFile = {
     activityReportId: reportId,
     originalFileName,


### PR DESCRIPTION
Currently if you add files then click on Review, you get the following error.
`Error: Objects are not valid as a React child (found: object with keys {id, activityReportId, originalFileName, key, status, attachmentType, fileSize, createdAt, updatedAt}). If you meant to render a collection of children, use an array instead.`

This is cause by the way the review page renders the values.

This patch adds handling for attachments and other resources on the review page.

To test:
1. pull down changes
2. add files to attachments
3. click on review.
4. make sure there are no errors