### PR TITLE
Increase wait time for the server to spin up in cucummber ci tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,7 +228,7 @@ jobs:
       - run:
           name: Run cucumber
           command: |
-            sleep 5
+            sleep 10
             yarn cucumber:ci
       - store_artifacts:
           path: reports/


### PR DESCRIPTION
**Description of change**
Cucumber tests sometimes fail on CI with an error like:

```
   ✖ Given I am logged in # cucumber/features/steps/homePageSteps.js:9
       Error: net::ERR_CONNECTION_REFUSED at *********************
```

I've increased the sleep time waiting for the server so the cucumber tests hit the server once it is running.