### PR TITLE
Add locked users filter to admin UI

### DIFF
--- a/frontend/src/pages/Admin/__tests__/index.js
+++ b/frontend/src/pages/Admin/__tests__/index.js
@@ -10,6 +10,7 @@ import fetchMock from 'fetch-mock';
 import join from 'url-join';
 
 import Admin from '../index';
+import { SCOPE_IDS } from '../../../Constants';
 
 describe('Admin Page', () => {
   const usersUrl = join('/api', 'admin', 'users');
@@ -41,7 +42,11 @@ describe('Admin Page', () => {
         name: 'Harry Potter',
         homeRegionId: 1,
         role: 'Grantee Specialist',
-        permissions: [],
+        permissions: [{
+          userId: 3,
+          scopeId: SCOPE_IDS.SITE_ACCESS,
+          regionId: 14,
+        }],
       },
     ];
 
@@ -54,7 +59,7 @@ describe('Admin Page', () => {
         render(<Router history={history}><Admin match={{ path: '', url: '', params: { userId: undefined } }} /></Router>);
       });
 
-      it('user list is filterable', async () => {
+      it('user list is filterable by name', async () => {
         const filter = await screen.findByLabelText('Filter Users');
         userEvent.type(filter, 'Harry');
         const sideNav = screen.getByTestId('sidenav');
@@ -78,6 +83,15 @@ describe('Admin Page', () => {
         const links = within(sideNav).getAllByRole('link');
         expect(links.length).toBe(1);
         expect(links[0]).toHaveTextContent('Harry Potter');
+      });
+
+      it('user list is filterable by SITE_ACCESS permission', async () => {
+        const checkbox = await screen.findByRole('checkbox', { name: 'Show Only Locked Users' });
+        userEvent.click(checkbox);
+        const sideNav = screen.getByTestId('sidenav');
+        const links = within(sideNav).getAllByRole('link');
+        expect(links.length).toBe(1);
+        expect(links[0]).toHaveTextContent('gs@hogwarts.com');
       });
 
       it('allows a user to be selected', async () => {


### PR DESCRIPTION
**Description of change**

Adds a checkbox filter for all users without SITE_ACCESS permissions

**How to test**

Log in as an admin, select the checkbox to see only dumbledore@hogwarts

**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/278

**Checklist**
<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] Code tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [x] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
