### PR TITLE
Document bin/run-tests, make sure frontend tests run in frontend instance

### DIFF
--- a/bin/run-tests
+++ b/bin/run-tests
@@ -16,7 +16,7 @@ docker exec test-backend bash -c "yarn db:seed;"
 docker exec test-backend bash -c "yarn test:ci"
 
 # Test frontend
-docker exec test-backend bash -c "yarn --cwd frontend run test:ci"
+docker exec test-frontend bash -c "yarn --cwd frontend run test:ci"
 
 # Cleanup
 docker-compose \

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -26,6 +26,12 @@ When writing tests that create database records, it might also help to use a `tr
 
 ## Testing in Docker
 
+### Using `./bin/run-tests`
+
+To simplify running tests in Docker, there is a bash script, `./bin/run-tests` that will run the appropriate commands to start `test-` variations of the services used in tests. You should be able to run tests using that command while your development Docker environment is running. The script uses a separate `docker-compose.test.yml` which does not create a user-accessible network and cleans up after itself once tests have run.
+
+### Running tests in your development Docker environment
+
 When running tests in Docker, be aware that there are tests that will modify/delete database records. For tests to run, the 'db' service needs to exist and `db:migrate` and `db:seed` need to have been run (to create the tables and populate certain records).
 
 In the `docker-compose.yml` configuration, the database is set up to persist to a volume, "dbdata", so database records will persist between runs of the 'db' service, unless you remove that volume explicitly (e.g. `docker volume rm` or `docker-compose down --volumes`).


### PR DESCRIPTION
**Description of change**

Per feedback on https://github.com/HHS/Head-Start-TTADP/pull/281, I changed `./bin/run-tests` to use test-frontend properly, and added documentation about aforementioned script to the docs/testing.md doc.

**How to test**

Run `./bin/run-tests`

**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/263

**Checklist**
<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] Code tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
