### PR TITLE
Improvements and fixes to bin/run-tests

### DIFF
--- a/bin/run-tests
+++ b/bin/run-tests
@@ -1,24 +1,52 @@
 #!/bin/bash
 
-echo "Running tests in using test config 'docker-compose.test.yml'"
-# Start containers
-docker-compose -f 'docker-compose.test.yml' up -d
+declare -a options=(frontend backend)
+declare lr=">>>>>>>>"
 
-# Let postgres initialize
-echo "Give postgres a few seconds to start up..."
-sleep 5
+echo_heading() {
+    echo
+    echo "$lr" "$*"
+}
 
-# Migrate and seed db
-docker exec test-backend bash -c "yarn db:migrate"
-docker exec test-backend bash -c "yarn db:seed;"
+main(){
+    local opt=""
 
-# Test backend
-docker exec test-backend bash -c "yarn test:ci"
+    for o in "${options[@]}"; do
+        if [[ "${1}" == "$o"  ]]; then
+            opt="$o";
+        fi
+    done
 
-# Test frontend
-docker exec test-frontend bash -c "yarn --cwd frontend run test:ci"
+    echo_heading "Running tests in using test config 'docker-compose.test.yml'"
+    # Start containers
+    docker-compose -f 'docker-compose.test.yml' up -d
 
-# Cleanup
-docker-compose \
-    -f 'docker-compose.test.yml' \
-    down --volumes
+    # Let postgres initialize
+    echo_heading "Giving postgres a few seconds to start up..."
+    sleep 5
+
+    # Migrate and seed db
+    echo_heading "Migrating & seeding db"
+    docker exec test-backend bash -c "yarn db:migrate"
+    docker exec test-backend bash -c "yarn db:seed;"
+
+    if [[ "$opt" == "backend" || -z "$opt" ]]; then
+        # Test backend
+        echo_heading "Running backend tests"
+        docker exec test-backend bash -c "yarn test:ci"
+    fi
+
+    if [[ "$opt" == "frontend" || -z "$opt" ]]; then
+        # Test frontend
+        echo_heading "Running frontend tests"
+        docker exec test-frontend bash -c "yarn --cwd frontend run test:ci"
+    fi
+
+    # Cleanup
+    echo_heading "Cleaning up test containers"
+    docker-compose \
+        -f 'docker-compose.test.yml' \
+        down --volumes
+}
+
+main "$@"

--- a/bin/run-tests
+++ b/bin/run-tests
@@ -2,13 +2,20 @@
 
 declare -a options=(frontend backend)
 declare lr=">>>>>>>>"
+declare -i exit_code=0
 
-echo_heading() {
-    echo
-    echo "$lr" "$*"
+log() {
+    echo "$lr $*"
 }
 
-main(){
+check_exit() {
+    if [[ "$1" -ne 0 ]]; then
+        echo "$lr last docker-compose command failed"
+        ((exit_code++))
+    fi
+}
+
+main() {
     local opt=""
 
     for o in "${options[@]}"; do
@@ -17,36 +24,54 @@ main(){
         fi
     done
 
-    echo_heading "Running tests in using test config 'docker-compose.test.yml'"
+    log "Running tests in using test config 'docker-compose.test.yml'"
     # Start containers
     docker-compose -f 'docker-compose.test.yml' up -d
+    check_exit "$?"
 
     # Let postgres initialize
-    echo_heading "Giving postgres a few seconds to start up..."
+    echo
+    log "Giving postgres a few seconds to start up..."
     sleep 5
 
     # Migrate and seed db
-    echo_heading "Migrating & seeding db"
+    echo
+    log "Migrating & seeding db"
     docker exec test-backend bash -c "yarn db:migrate"
+    check_exit "$?"
     docker exec test-backend bash -c "yarn db:seed;"
+    check_exit "$?"
 
     if [[ "$opt" == "backend" || -z "$opt" ]]; then
         # Test backend
-        echo_heading "Running backend tests"
+        echo
+        log "Running backend tests"
         docker exec test-backend bash -c "yarn test:ci"
+        check_exit "$?"
     fi
 
     if [[ "$opt" == "frontend" || -z "$opt" ]]; then
         # Test frontend
-        echo_heading "Running frontend tests"
+        echo
+        log "Running frontend tests"
         docker exec test-frontend bash -c "yarn --cwd frontend run test:ci"
+        check_exit "$?"
     fi
 
     # Cleanup
-    echo_heading "Cleaning up test containers"
+    echo
+    log "Cleaning up test containers"
     docker-compose \
         -f 'docker-compose.test.yml' \
         down --volumes
+    check_exit "$?"
+
+    if [[ $exit_code -ne 0 ]]; then
+        echo
+        log "Errors occurred during script execution"
+    fi
+
+    exit "$exit_code"
 }
 
 main "$@"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -17,6 +17,7 @@ services:
   test-frontend:
     build:
       context: .
+    container_name: test-frontend
     command: yarn start
     user: ${CURRENT_USER:-root}
     stdin_open: true

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -30,6 +30,8 @@ When writing tests that create database records, it might also help to use a `tr
 
 To simplify running tests in Docker, there is a bash script, `./bin/run-tests` that will run the appropriate commands to start `test-` variations of the services used in tests. You should be able to run tests using that command while your development Docker environment is running. The script uses a separate `docker-compose.test.yml` which does not create a user-accessible network and cleans up after itself once tests have run.
 
+This script is written such that it will log errors, but won't exit if a docker command fails. It will count the number of errors and the number of errors will be the exit code (`$?`) for the script. So if three docker commands fail, the exit code would be 3.
+
 By default, `./bin/run-tests` will run both backend and frontend tests. If you want to run only one set of tests, supply 'frontend' or 'backend' as a parameter. So to run only the backend tests, you'd run `./bin/run-tests backend`.
 
 ### Running tests in your development Docker environment

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -30,6 +30,8 @@ When writing tests that create database records, it might also help to use a `tr
 
 To simplify running tests in Docker, there is a bash script, `./bin/run-tests` that will run the appropriate commands to start `test-` variations of the services used in tests. You should be able to run tests using that command while your development Docker environment is running. The script uses a separate `docker-compose.test.yml` which does not create a user-accessible network and cleans up after itself once tests have run.
 
+By default, `./bin/run-tests` will run both backend and frontend tests. If you want to run only one set of tests, supply 'frontend' or 'backend' as a parameter. So to run only the backend tests, you'd run `./bin/run-tests backend`.
+
 ### Running tests in your development Docker environment
 
 When running tests in Docker, be aware that there are tests that will modify/delete database records. For tests to run, the 'db' service needs to exist and `db:migrate` and `db:seed` need to have been run (to create the tables and populate certain records).


### PR DESCRIPTION
**Description of change**

During upstream testing, a bug was revealed with respect to the container_name of the 'test-frontend' service. This fixes that.

This PR also adds params to the `bin/run-tests` command, so you can run just the frontend or just the backend tests, e.g. `./bin/run-tests frontend`.

Finally, the command will 'log' errors thrown by docker commands, and return an exit status equal to the number of errors. The command will not exit on docker-compose errors. This way if you are running both frontend and backend tests, failures in one set won't prevent the other from running.

- Somehow service == container_name for docker-compose exec
- Add param to run-tests to choose to run only frontend or backend tests. More echo statements, too
- Check exit codes of docker cmds, and 'log' errors. Return exit_code equal to number of errors that occurred.


**How to test**

`./bin/run-tests frontend` to run only frontend tests.  `./bin/run-tests backend` to run only backend tests. `./bin/run-tests` to run both. If you want to trigger failures, edit the script to introduce errors. For example find/replace 'test-backend' with 'fail-fail-fail'.

**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/0

**Checklist**
<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] Code tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
