### PR TITLE
Add missing deps to admin use memo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ parameters:
     default: "main"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
-    default: "js-109-add-collaborators"
+    default: "js-add-missing-deps-to-admin-use-memo"
     type: string
 jobs:
   build_and_lint:

--- a/frontend/src/pages/Admin/index.js
+++ b/frontend/src/pages/Admin/index.js
@@ -100,7 +100,7 @@ function Admin(props) {
       }
       return userMatchesFilter && userMatchesLockFilter;
     })
-  ), [users, userSearch, lockedFilter]);
+  ), [users, userSearch, lockedFilter, disableThreshold, lockThreshold]);
 
   if (!isLoaded) {
     return (


### PR DESCRIPTION
**Description of change**
There is a rule for most of the react hooks that take dependencies that requires them to specify every dependency used by the hook (https://reactjs.org/docs/hooks-rules.html#eslint-plugin). This specific use of `useMemo` was missing two dependencies.

See https://app.circleci.com/pipelines/github/adhocteam/Head-Start-TTADP/1239/workflows/f6dc956f-5c71-45a3-80c2-9c6ef1b8b703/jobs/6402

**How to test**

* Check if the build of this branch in circle ci successfully deploys to sandbox
