### PR TITLE
Try limiting workers for frontend tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,7 +203,7 @@ jobs:
             ./run-yarn-audit.sh;
       - run:
           name: Test frontend
-          command: yarn --cwd frontend run test:ci
+          command: yarn --cwd frontend run test:ci --maxWorkers=50%
       - store_test_results:
           path: frontend/reports/
       - store_artifacts:


### PR DESCRIPTION
**Description of change**
To eliminate `Call retries were exceeded` error for frontend tests
Add --maxWorkers=50% as suggested at
https://github.com/facebook/jest/issues/8769

**How to test**
Do frontend tests pass in circlieci
