### PR TITLE
fix typo where generateS3Config wasn't called in worker/src/s3.js

### DIFF
--- a/worker/src/s3.js
+++ b/worker/src/s3.js
@@ -27,8 +27,7 @@ const generateS3Config = () => {
   };
 };
 
-const { bucketName, s3Config } = generateS3Config;
-
+const { bucketName, s3Config } = generateS3Config();
 const s3 = new S3(s3Config);
 
 function downloadFile(key) {


### PR DESCRIPTION
**Description of change**
Fix a small bug where I forgot some parens.

**How to test**
Make sure file scanning works

**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/204

**Checklist**
<!-- Add details to each completed item -->
- [X] Meets issue criteria
- [X] Code tested
- [X] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [X] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
