### PR TITLE
simplify file upload statuses

### DIFF
--- a/frontend/src/components/FileUploader.js
+++ b/frontend/src/components/FileUploader.js
@@ -78,7 +78,7 @@ Dropzone.propTypes = {
   id: PropTypes.string.isRequired,
 };
 
-const getStatus = (status) => {
+export const getStatus = (status) => {
   switch (status) {
     case 'UPLOADING':
       return 'Uploading';

--- a/frontend/src/components/FileUploader.js
+++ b/frontend/src/components/FileUploader.js
@@ -78,6 +78,30 @@ Dropzone.propTypes = {
   id: PropTypes.string.isRequired,
 };
 
+const getStatus = (status) => {
+  switch (status) {
+    case 'UPLOADING':
+      return 'Uploading';
+    case 'UPLOADED':
+      return 'Uploaded';
+    case 'UPLOAD_FAILED':
+      return 'Upload Failed';
+    case 'SCANNING_QUEUED':
+      return 'Scanning';
+    case 'QUEUEING_FAILED':
+      return 'Upload Failed';
+    case 'SCANNING':
+      return 'Scanning';
+    case 'APPROVED':
+      return 'Approved';
+    case 'REJECTED':
+      return 'Rejected';
+    default:
+      break;
+  }
+  return 'Upload Failed';
+};
+
 const FileTable = ({ onFileRemoved, files }) => (
   <div className="files-table--container margin-top-2">
     <table className="files-table">
@@ -106,7 +130,7 @@ const FileTable = ({ onFileRemoved, files }) => (
               {`${(file.fileSize / 1000).toFixed(1)} KB`}
             </td>
             <td>
-              {file.status}
+              {getStatus(file.status)}
             </td>
             <td>
               <Button

--- a/frontend/src/components/__tests__/FileUploader.js
+++ b/frontend/src/components/__tests__/FileUploader.js
@@ -4,9 +4,7 @@ import {
   render, fireEvent, waitFor, act, screen,
 } from '@testing-library/react';
 import * as fileFetcher from '../../fetchers/File';
-import { getStatus } from '../FileUploader';
-
-import FileUploader from '../FileUploader';
+import FileUploader, { getStatus } from '../FileUploader';
 
 describe('FileUploader', () => {
   jest.spyOn(fileFetcher, 'default').mockImplementation(() => Promise.resolve());
@@ -75,24 +73,24 @@ describe('FileUploader', () => {
     expect(mockOnChange).toHaveBeenCalledWith([file('fileOne')]);
   });
   describe('getStatus tests', () => {
-    it('returns the correct statuses', () =>{
+    it('returns the correct statuses', () => {
       let got;
       got = getStatus('UPLOADING');
-      expect(got).toBe('Uploading')
+      expect(got).toBe('Uploading');
       got = getStatus('UPLOADED');
-      expect(got).toBe('Uploaded')
+      expect(got).toBe('Uploaded');
       got = getStatus('UPLOAD_FAILED');
-      expect(got).toBe('Upload Failed')
+      expect(got).toBe('Upload Failed');
       got = getStatus('QUEUING_FAILED');
-      expect(got).toBe('Upload Failed')
+      expect(got).toBe('Upload Failed');
       got = getStatus('SCANNING_QUEUED');
-      expect(got).toBe('Scanning')
+      expect(got).toBe('Scanning');
       got = getStatus('SCANNING');
-      expect(got).toBe('Scanning')
+      expect(got).toBe('Scanning');
       got = getStatus('APPROVED');
-      expect(got).toBe('Approved')
+      expect(got).toBe('Approved');
       got = getStatus('REJECTED');
-      expect(got).toBe('Rejected')
-    })
+      expect(got).toBe('Rejected');
+    });
   });
 });

--- a/frontend/src/components/__tests__/FileUploader.js
+++ b/frontend/src/components/__tests__/FileUploader.js
@@ -4,6 +4,7 @@ import {
   render, fireEvent, waitFor, act, screen,
 } from '@testing-library/react';
 import * as fileFetcher from '../../fetchers/File';
+import { getStatus } from '../FileUploader';
 
 import FileUploader from '../FileUploader';
 
@@ -72,5 +73,26 @@ describe('FileUploader', () => {
     fireEvent.click(fileTwo.parentNode.lastChild.firstChild);
 
     expect(mockOnChange).toHaveBeenCalledWith([file('fileOne')]);
+  });
+  describe('getStatus tests', () => {
+    it('returns the correct statuses', () =>{
+      let got;
+      got = getStatus('UPLOADING');
+      expect(got).toBe('Uploading')
+      got = getStatus('UPLOADED');
+      expect(got).toBe('Uploaded')
+      got = getStatus('UPLOAD_FAILED');
+      expect(got).toBe('Upload Failed')
+      got = getStatus('QUEUING_FAILED');
+      expect(got).toBe('Upload Failed')
+      got = getStatus('SCANNING_QUEUED');
+      expect(got).toBe('Scanning')
+      got = getStatus('SCANNING');
+      expect(got).toBe('Scanning')
+      got = getStatus('APPROVED');
+      expect(got).toBe('Approved')
+      got = getStatus('REJECTED');
+      expect(got).toBe('Rejected')
+    })
   });
 });


### PR DESCRIPTION
**Description of change**
Simplified file statuses presented to user. The mapping is now 

UPLOADING -> Uploading
UPLOADED -> Uploaded
UPLOAD_FAILED, QUEUING_FAILED -> Upload Failed
SCANNING_QUEUED, SCANNING -> Scanning
APPROVED -> Approved
REJECTED -> Rejected.

Once https://github.com/HHS/Head-Start-TTADP/issues/317 is complete, then QUEUING_FAILED will be moved to Scanning since it will have retry for failed queuing.

**How to test**
1. Pull down changes.
2. Start the app
3. While the clamav instance is still starting add a grantee, click save draft, and upload a file
4. File status should display 'Uploaded'
5. Refresh the page, File status should display 'Scanning'
6. Wait for ClamAV to finish starting and for a success message from the worker.
7. Refresh the page and status should now say 'Approved'
8. Stop the redis instance (`docker stop head-start-ttadp_redis_1`)
9. Upload a new file
10. Status should be uploaded. It will stay uploaded until the request to que times out (approx 2 mins)
11. Go make a cup of coffee or tea
12. Come back and refresh the page. If status is still 'Updated ' then the request hasn't timed out yet
13. Refresh the page, status should now be 'Upload Failed'
Note: if you start redis again within the timeout period then queuing will succeed and the job will get processed, so we currently have some resiliency there for dropouts.
**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/310

**Checklist**
<!-- Add details to each completed item -->
- [X] Meets issue criteria
- [X] Code tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
