### PR TITLE
Include --command and --name arguments on run-task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ parameters:
     default: "main"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
-    default: "js-6-frontend-validations"
+    default: "fix-cf7-run-task"
     type: string
 jobs:
   build_and_lint:
@@ -317,7 +317,8 @@ jobs:
                 name: Return database to neutral, then migrate and seed
                 command: |
                   cf run-task tta-smarthub-sandbox \
-                  "yarn db:migrate:undo:prod && yarn db:migrate:prod && yarn db:seed:prod"
+                    --command "yarn db:migrate:undo:prod && yarn db:migrate:prod && yarn db:seed:prod" \
+                    --name "Reset DB"
       - when:  # dev
           condition:
             and:
@@ -340,7 +341,9 @@ jobs:
             - run:
                 name: Undo database seeding, then migrate and seed
                 command: |
-                  cf run-task tta-smarthub-dev "yarn db:migrate:prod && yarn db:seed:undo:prod && yarn db:seed:prod"
+                  cf run-task tta-smarthub-dev \
+                    --command "yarn db:migrate:prod && yarn db:seed:undo:prod && yarn db:seed:prod" \
+                    --name "Reset DB"
       - when:  # staging
           condition:
             and:
@@ -363,7 +366,7 @@ jobs:
             - run:
                 name: Run database migrations
                 command: |
-                  cf run-task tta-smarthub-staging "yarn db:migrate:prod"
+                  cf run-task tta-smarthub-staging --command "yarn db:migrate:prod" --name migrate
       - when:  # prod
           condition:
             and:
@@ -386,7 +389,7 @@ jobs:
             - run:
                 name: Run database migrations
                 command: |
-                  cf run-task tta-smarthub-prod "yarn db:migrate:prod"
+                  cf run-task tta-smarthub-prod --command "yarn db:migrate:prod" --name migrate
 workflows:
   build_test_deploy:
     jobs:

--- a/src/tools/bootstrapAdminCLI.js
+++ b/src/tools/bootstrapAdminCLI.js
@@ -3,7 +3,7 @@ import { auditLogger } from '../logger';
 
 /**
  * bootstrapAdminCLI is responsible for setting the first ADMIN for TTA Smart Hub.
- * It should be run via `cf run-task tta-smarthub-prod "yarn db:bootstrap:admin"`
+ * It should be run via `cf run-task tta-smarthub-prod --command "yarn db:bootstrap:admin"`
  *
  * All other admins and permissions should be set via the admin UI.
  *


### PR DESCRIPTION
**Description of change**

CF version 7 has a new required parameter for `run-task`. This is needed before https://github.com/HHS/Head-Start-TTADP/pull/326 can be merged

**How to test**

[Sandbox deploy is successful](https://app.circleci.com/pipelines/github/adhocteam/Head-Start-TTADP/1590/workflows/505d1bf6-4c67-42a9-84d0-cc55c92aca90/jobs/8487)

**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/pull/326

**Checklist**
<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] Code tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [x] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
