### PR TITLE
Include the context menu in the activity reports table

### DIFF
--- a/frontend/src/pages/Landing/__tests__/index.js
+++ b/frontend/src/pages/Landing/__tests__/index.js
@@ -85,7 +85,7 @@ describe('Landing Page', () => {
     expect(reportIdLink).toBeVisible();
     expect(reportIdLink.closest('a')).toHaveAttribute(
       'href',
-      '/activity-reports/1/activity-summary',
+      '/activity-reports/1',
     );
   });
 

--- a/frontend/src/pages/Landing/index.css
+++ b/frontend/src/pages/Landing/index.css
@@ -111,17 +111,12 @@ h1.landing {
   overflow: hidden;
   text-overflow: ellipsis;
   display: inline-block;
-  width: 210px;
+  width: 200px;
   vertical-align: middle;
 }
 
-.smart-hub--dotdotdot {
-  font-size: 25px;
-  font-weight: bold;
-  border: none;
-  background: transparent;
-  padding-bottom: 15px;
-  line-height: 0.75;
+.usa-button.smart-hub--button__no-margin {
+  margin-left: 0px;
 }
 
 .smart-hub--plus {

--- a/frontend/src/pages/Landing/index.js
+++ b/frontend/src/pages/Landing/index.js
@@ -3,7 +3,7 @@ import {
   Tag, Table, Alert, Grid,
 } from '@trussworks/react-uswds';
 import { Helmet } from 'react-helmet';
-import { Link } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import SimpleBar from 'simplebar-react';
 import 'simplebar/dist/simplebar.min.css';
 
@@ -16,8 +16,9 @@ import '@trussworks/react-uswds/lib/index.css';
 import './index.css';
 import MyAlerts from './MyAlerts';
 import { hasReadWrite } from '../../permissions';
+import ContextMenu from '../../components/ContextMenu';
 
-function renderReports(reports) {
+function renderReports(reports, history) {
   const emptyReport = {
     id: '',
     displayId: '',
@@ -87,12 +88,20 @@ function renderReports(reports) {
       </Tag>
     ));
 
+    const menuItems = [
+      {
+        label: 'Edit',
+        onClick: () => { history.push(`/activity-reports/${id}`); },
+      },
+    ];
+    const contextMenuLabel = `Edit activity report ${displayId}`;
+
     return (
       <tr key={`landing_${id}`}>
         <th scope="row">
           <Link
-            to={`/activity-reports/${id}/activity-summary`}
-            href={`/activity-reports/${id}/activity-summary`}
+            to={`/activity-reports/${id}`}
+            href={`/activity-reports/${id}`}
           >
             {displayId}
           </Link>
@@ -127,9 +136,7 @@ function renderReports(reports) {
           </Tag>
         </td>
         <td>
-          <button type="button" className="smart-hub--dotdotdot">
-            ...
-          </button>
+          <ContextMenu label={contextMenuLabel} menuItems={menuItems} />
         </td>
       </tr>
     );
@@ -137,6 +144,7 @@ function renderReports(reports) {
 }
 
 function Landing() {
+  const history = useHistory();
   const [isLoaded, setIsLoaded] = useState(false);
   const [reports, updateReports] = useState([]);
   const [reportAlerts, updateReportAlerts] = useState([]);
@@ -205,7 +213,7 @@ function Landing() {
                       <th scope="col" aria-label="..." />
                     </tr>
                   </thead>
-                  <tbody>{renderReports(reports)}</tbody>
+                  <tbody>{renderReports(reports, history)}</tbody>
                 </Table>
               </Container>
             </SimpleBar>


### PR DESCRIPTION
**Description of change**
Uses the ContextMenu component for the row specific menu.

**How to test**
- Pull changes
- Verify that the "..." menu has the "Edit" option which navigates to the correct activity report

**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/0

**Checklist**
<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] Code tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
