### PR TITLE
File upload test shouldn't error out

### DIFF
--- a/src/routes/files/handlers.test.js
+++ b/src/routes/files/handlers.test.js
@@ -80,11 +80,9 @@ describe('File Upload', () => {
   });
 
   describe('File Upload Handlers happy path', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       uploadFile.mockReset();
       getPresignedURL.mockReset();
-    });
-    it('tests a file upload', async () => {
       ActivityReportPolicy.mockImplementation(() => ({
         canUpdate: () => true,
       }));
@@ -96,8 +94,10 @@ describe('File Upload', () => {
         .expect(200)
         .then((res) => {
           fileId = res.body.id;
-          expect(uploadFile).toHaveBeenCalled();
         });
+    });
+    it('tests a file upload', async () => {
+      expect(uploadFile).toHaveBeenCalled();
       expect(mockAddToScanQueue).toHaveBeenCalled();
     });
     it('checks the metadata was uploaded to the database', async () => {


### PR DESCRIPTION
`FileId` is now set in a before each and should no longer depend on tests being ran in a specific order.
