### PR TITLE
add 403 and 401 status codes to expected_status_code in newrelic.js

### DIFF
--- a/src/newrelic.js
+++ b/src/newrelic.js
@@ -80,4 +80,10 @@ exports.config = {
       'response.headers.x*',
     ],
   },
+  error_collector: {
+    expected_status_codes: [
+      '401',
+      '403',
+    ],
+  },
 };


### PR DESCRIPTION
**Description of change**
Add 401 and 403 as expected errors in the New Relic configuration. This will keep them from showing up in the error rate and causing alerts to fire.
Documentation is at https://docs.newrelic.com/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration/

**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/367

**Checklist**
<!-- Add details to each completed item -->
- [X] Meets issue criteria
- [ ] Code tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
