### PR TITLE
Goal import in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "server:debug": "nodemon src/index.js --exec babel-node --inspect",
     "client": "yarn --cwd frontend start",
     "test": "jest src --runInBand",
-    "test:ci": "cross-env JEST_JUNIT_OUTPUT_DIR=reports JEST_JUNIT_OUTPUT_NAME=unit.xml POSTGRES_USERNAME=postgres POSTGRES_DB=ttasmarthub CURRENT_USER_ID=5 CI=true jest src --coverage --reporters=default --reporters=jest-junit --forceExit",
+    "test:ci": "cross-env JEST_JUNIT_OUTPUT_DIR=reports JEST_JUNIT_OUTPUT_NAME=unit.xml POSTGRES_USERNAME=postgres POSTGRES_DB=ttasmarthub CURRENT_USER_ID=5 CI=true jest src --coverage --reporters=default --reporters=jest-junit",
     "test:all": "yarn test:ci && yarn --cwd frontend test:ci",
     "lint": "eslint src",
     "lint:ci": "eslint -f eslint-formatter-multiple src",

--- a/src/tools/importPlanGoals.js
+++ b/src/tools/importPlanGoals.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-restricted-syntax */
 /* eslint-disable no-loop-func */
-import { readFileSync } from 'fs';
+import { downloadFile } from '../lib/s3';
 import parse from 'csv-parse/lib/sync';
 import {
   Role, Topic, RoleTopic, Goal, TopicGoal, Grant, GrantGoal,
@@ -25,9 +25,9 @@ const hubRoles = [
   { name: 'SS', fullName: 'System Specialist' },
 ];
 
-function parseCsv(file) {
+async function parseCsv(fileKey) {
   let grantees = {};
-  const csv = readFileSync(file);
+  const { Body: csv } = await downloadFile(fileKey);
   [...grantees] = parse(csv, {
     skipEmptyLines: true,
     columns: true,
@@ -59,9 +59,9 @@ async function prePopulateRoles() {
  * ...
  * (Total 5 goals. Some of them could be empty)
  */
-export default async function importGoals(file, region) {
-  const grantees = parseCsv(file);
-  const regionId = region || 14; // default to region 14
+export default async function importGoals(fileKey, region) {
+  const grantees = await parseCsv(fileKey);
+  const regionId = region;
   try {
     const cleanRoleTopics = [];
     const cleanGrantGoals = [];

--- a/src/tools/importPlanGoals.js
+++ b/src/tools/importPlanGoals.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-restricted-syntax */
 /* eslint-disable no-loop-func */
-import { downloadFile } from '../lib/s3';
 import parse from 'csv-parse/lib/sync';
+import { downloadFile } from '../lib/s3';
 import {
   Role, Topic, RoleTopic, Goal, TopicGoal, Grant, GrantGoal,
 } from '../models';

--- a/src/tools/importPlanGoals.test.js
+++ b/src/tools/importPlanGoals.test.js
@@ -1,18 +1,28 @@
 import importGoals from './importPlanGoals';
+import { downloadFile } from '../lib/s3';
+import { readFileSync } from 'fs';
 import db, {
   Role, Topic, RoleTopic, Goal, Grantee, Grant,
 } from '../models';
 
+jest.mock('../lib/s3');
+
 describe('Import TTA plan goals', () => {
-  afterAll(() => {
-    db.sequelize.close();
+  beforeEach(() => {
+    downloadFile.mockReset();
+  });
+  afterAll(async () => {
+    await db.sequelize.close();
   });
   it('should import Roles table', async () => {
+    const fileName = 'GranteeTTAPlanTest.csv';
+    downloadFile.mockResolvedValue({ Body: readFileSync(fileName) });
+
     await Role.destroy({ where: {} });
     const rolesBefore = await Role.findAll();
 
     expect(rolesBefore.length).toBe(0);
-    await importGoals('GranteeTTAPlanTest.csv');
+    await importGoals(fileName, 14);
 
     const roles = await Role.findAll({
       attributes: ['id', 'name', 'fullName'],
@@ -59,11 +69,14 @@ describe('Import TTA plan goals', () => {
   });
 
   it('should import Topics table', async () => {
+    const fileName = 'GranteeTTAPlanTest.csv';
+    downloadFile.mockResolvedValue({ Body: readFileSync(fileName) });
+
     await Topic.destroy({ where: {} });
     const topicsBefore = await Topic.findAll();
 
     expect(topicsBefore.length).toBe(0);
-    await importGoals('GranteeTTAPlanTest.csv');
+    await importGoals(fileName, 14);
 
     const topics = await Topic.findAll();
     expect(topics).toBeDefined();
@@ -104,11 +117,14 @@ describe('Import TTA plan goals', () => {
   });
 
   it('should import Goals table', async () => {
+    const fileName = 'GranteeTTAPlanTest.csv';
+    downloadFile.mockResolvedValue({ Body: readFileSync(fileName) });
+
     await Goal.destroy({ where: {} });
     const goalsBefore = await Goal.findAll();
 
     expect(goalsBefore.length).toBe(0);
-    await importGoals('GranteeTTAPlanTest.csv');
+    await importGoals(fileName, 14);
 
     const allGoals = await Goal.findAll();
     expect(allGoals).toBeDefined();
@@ -166,7 +182,10 @@ describe('Import TTA plan goals', () => {
   });
 
   it('should have Grantees Goals connection', async () => {
-    await importGoals('GranteeTTAPlanTest.csv');
+    const fileName = 'GranteeTTAPlanTest.csv';
+    downloadFile.mockResolvedValue({ Body: readFileSync(fileName) });
+
+    await importGoals(fileName, 14);
 
     // test eager loading
     const grantee = await Grantee.findOne({
@@ -188,12 +207,15 @@ describe('Import TTA plan goals', () => {
   });
 
   it('should import RoleTopics table', async () => {
+    const fileName = 'GranteeTTAPlanTest.csv';
+    downloadFile.mockResolvedValue({ Body: readFileSync(fileName) });
+
     await Topic.destroy({ where: {} });
 
     const roleTopicsBefore = await RoleTopic.findAll();
 
     expect(roleTopicsBefore.length).toBe(0);
-    await importGoals('GranteeTTAPlanTest.csv', 14);
+    await importGoals(fileName, 14);
 
     const roleTopics = await RoleTopic.findAll();
     expect(roleTopics).toBeDefined();
@@ -201,10 +223,13 @@ describe('Import TTA plan goals', () => {
   });
 
   it('should import goals from another region', async () => {
+    const fileName = 'R9GranteeTTAPlanTest.csv';
+    downloadFile.mockResolvedValue({ Body: readFileSync(fileName) });
+
     const goalsBefore = await Goal.findAll();
 
     expect(goalsBefore.length).toBe(12);
-    await importGoals('R9GranteeTTAPlanTest.csv', 9);
+    await importGoals(fileName, 9);
 
     const allGoals = await Goal.findAll();
     expect(allGoals).toBeDefined();
@@ -273,4 +298,25 @@ describe('Import TTA plan goals', () => {
     });
     expect(goalWithTopic.topics[0].roles[0].fullName).toBe('Grantee Specialist');
   });
+
+  it('is idempotent', async () => {
+    const fileName = 'GranteeTTAPlanTest.csv';
+    downloadFile.mockResolvedValue({ Body: readFileSync(fileName) });
+
+    await Goal.destroy({ where: {} });
+    const goalsBefore = await Goal.findAll();
+
+    expect(goalsBefore.length).toBe(0);
+    await importGoals(fileName, 14);
+
+    const allGoals = await Goal.findAll();
+    expect(allGoals).toBeDefined();
+    expect(allGoals.length).toBe(12);
+
+    await importGoals(fileName, 14);
+
+    const allGoals2 = await Goal.findAll();
+    expect(allGoals2).toBeDefined();
+    expect(allGoals2.length).toBe(12);
+  })
 });

--- a/src/tools/importPlanGoals.test.js
+++ b/src/tools/importPlanGoals.test.js
@@ -1,6 +1,6 @@
+import { readFileSync } from 'fs';
 import importGoals from './importPlanGoals';
 import { downloadFile } from '../lib/s3';
-import { readFileSync } from 'fs';
 import db, {
   Role, Topic, RoleTopic, Goal, Grantee, Grant,
 } from '../models';
@@ -318,5 +318,5 @@ describe('Import TTA plan goals', () => {
     const allGoals2 = await Goal.findAll();
     expect(allGoals2).toBeDefined();
     expect(allGoals2.length).toBe(12);
-  })
+  });
 });

--- a/src/tools/importTTAPlanGoals.js
+++ b/src/tools/importTTAPlanGoals.js
@@ -1,5 +1,7 @@
+import {} from 'dotenv/config';
 import { option } from 'yargs';
 import importGoals from './importPlanGoals';
+import { logger } from '../logger';
 
 const { argv } = option('file', {
   alias: 'f',
@@ -13,21 +15,16 @@ const { argv } = option('file', {
   .help()
   .alias('help', 'h');
 
-const defaultInputFile = './GranteeTTAPlan.csv';
-const defaultRegion = 14;
+const { file, region } = argv;
 
-let file;
-let region;
-if (argv.file) {
-  file = argv.file;
-} else {
-  file = defaultInputFile;
+if (!file) {
+  logger.error("File not provided to importTTAPlanGoals");
+  process.exit(1);
 }
 
-if (argv.region) {
-  region = argv.region;
-} else {
-  region = defaultRegion;
+if (!region) {
+  logger.error("Region not provided to importTTAPlanGoals");
+  process.exit(1);
 }
 
 importGoals(file, region);

--- a/src/tools/importTTAPlanGoals.js
+++ b/src/tools/importTTAPlanGoals.js
@@ -18,12 +18,12 @@ const { argv } = option('file', {
 const { file, region } = argv;
 
 if (!file) {
-  logger.error("File not provided to importTTAPlanGoals");
+  logger.error('File not provided to importTTAPlanGoals');
   process.exit(1);
 }
 
 if (!region) {
-  logger.error("Region not provided to importTTAPlanGoals");
+  logger.error('Region not provided to importTTAPlanGoals');
   process.exit(1);
 }
 


### PR DESCRIPTION
**Description of change**

* Retrieve goal csv files from s3 bucket
* Both command line flags are now required.
* Adding `await` to the db close in this test seemed to fix my local issues with open handles so 🤞🏻 

**How to test**

1. Run db seeds locally
2. Upload GranteeTTAPlanTest.csv to minio
3. Run `yarn import:goals:local -f GranteeTTAPlanTest.csv --region 14`

Note: using the shorthand `-r` does not work because babel-node swallows the argument and tries to require the `14` module, which doesn't work


**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/119

**Checklist**
<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [x] Code tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [x] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
