### PR TITLE
Filter main report table to approved reports

### DIFF
--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -429,9 +429,6 @@ export function activityReportAlerts(userId) {
                 {
                   status: { [Op.ne]: REPORT_STATUSES.APPROVED },
                 },
-                {
-                  status: { [Op.ne]: REPORT_STATUSES.SUBMITTED },
-                },
               ],
             },
             {

--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -328,7 +328,7 @@ export function activityReports(readRegions, {
   };
   return ActivityReport.findAndCountAll(
     {
-      where: { regionId: regions },
+      where: { regionId: regions, status: REPORT_STATUSES.APPROVED },
       attributes: [
         'id',
         'displayId',

--- a/src/services/activityReports.test.js
+++ b/src/services/activityReports.test.js
@@ -17,6 +17,7 @@ jest.mock('./goals', () => ({
 }));
 
 const RECIPIENT_ID = 15;
+const GRANTEE_ID = 16;
 
 const mockUser = {
   id: 1000,
@@ -74,10 +75,10 @@ describe('Activity Reports DB service', () => {
     await ActivityReport.destroy({ where: {} });
     await User.destroy({ where: { id: mockUser.id } });
     await NonGrantee.destroy({ where: { id: RECIPIENT_ID } });
-    await Grant.destroy({ where: { id: RECIPIENT_ID } });
-    await Grantee.destroy({ where: { id: RECIPIENT_ID } });
+    await Grant.destroy({ where: { id: [RECIPIENT_ID, GRANTEE_ID] } });
+    await Grantee.destroy({ where: { id: [RECIPIENT_ID, GRANTEE_ID] } });
     await Region.destroy({ where: { id: 17 } });
-    db.sequelize.close();
+    await db.sequelize.close();
   });
 
   afterEach(() => {
@@ -292,31 +293,71 @@ describe('Activity Reports DB service', () => {
   });
 
   describe('activityReports retrieval and sorting', () => {
-    it('retrieves reports with default sort by updatedAt', async () => {
-      const report = await ActivityReport.create(reportObject);
+    let latestReport;
+    let firstGrant;
 
-      const { count, rows } = await activityReports([1], {});
-      expect(rows.length).toBe(10);
-      expect(count).toBeDefined();
-      expect(rows[0].id).toBe(report.id);
-    });
+    const mockUserTwo = {
+      id: 1002,
+      homeRegionId: 1,
+      name: 'a user',
+      hsesUsername: 'user',
+      hsesUserId: '1002',
+    };
 
-    it('retrieves reports sorted by author', async () => {
-      const mockUserTwo = {
-        id: 1002,
-        homeRegionId: 1,
-        name: 'a user',
-        hsesUsername: 'user',
-        hsesUserId: '1002',
-      };
+    beforeAll(async () => {
+      const topicsOne = ['topic d', 'topic c'];
+      const topicsTwo = ['topic b', 'topic a'];
+      const firstGrantee = await Grantee.create({ id: GRANTEE_ID, name: 'aaaa' });
+      firstGrant = await Grant.create({ id: GRANTEE_ID, number: 'anumber', granteeId: firstGrantee.id });
+
       await User.findOrCreate({
         where: {
           id: mockUserTwo.id,
         },
         defaults: mockUserTwo,
       });
+      await ActivityReport.create({
+        ...submittedReport,
+        status: REPORT_STATUSES.APPROVED,
+        userId: mockUserTwo.id,
+        topics: topicsOne,
+      });
+      await createOrUpdate({
+        ...submittedReport,
+        status: REPORT_STATUSES.APPROVED,
+        collaborators: [{ id: mockUser.id }],
+      });
+      await ActivityReport.create({
+        ...submittedReport,
+        status: REPORT_STATUSES.APPROVED,
+        regionId: 2,
+      });
+      const report = await ActivityReport.create({
+        ...submittedReport,
+        activityRecipients: [{ grantId: firstGrant.id }],
+        status: REPORT_STATUSES.APPROVED,
+        topics: topicsTwo,
+      });
+      await ActivityRecipient.create({
+        activityReportId: report.id,
+        grantId: firstGrant.id,
+      });
+      latestReport = await ActivityReport.create({
+        ...submittedReport,
+        status: REPORT_STATUSES.APPROVED,
+        updatedAt: '1900-01-01T12:00:00Z',
+      });
+    });
+
+    it('retrieves reports with default sort by updatedAt', async () => {
+      const { count, rows } = await activityReports([1], {});
+      expect(rows.length).toBe(6);
+      expect(count).toBeDefined();
+      expect(rows[0].id).toBe(latestReport.id);
+    });
+
+    it('retrieves reports sorted by author', async () => {
       reportObject.userId = mockUserTwo.id;
-      await ActivityReport.create(reportObject);
 
       const { rows } = await activityReports([1], {
         sortBy: 'author', sortDir: 'asc', offset: 0, limit: 2,
@@ -331,7 +372,7 @@ describe('Activity Reports DB service', () => {
       const { rows } = await activityReports([1], {
         sortBy: 'collaborators', sortDir: 'asc', offset: 0, limit: 12,
       });
-      expect(rows.length).toBe(12);
+      expect(rows.length).toBe(6);
       expect(rows[0].collaborators[0].name).toBe('user');
     });
 
@@ -342,31 +383,26 @@ describe('Activity Reports DB service', () => {
       const { rows } = await activityReports([1, 2], {
         sortBy: 'regionId', sortDir: 'desc', offset: 0, limit: 12,
       });
-      expect(rows.length).toBe(12);
+      expect(rows.length).toBe(7);
       expect(rows[0].regionId).toBe(2);
     });
 
     it('retrieves reports sorted by activity recipients', async () => {
-      reportObject.regionId = 2;
-      await ActivityReport.create(reportObject);
-
       const { rows } = await activityReports([1, 2], {
         sortBy: 'activityRecipients', sortDir: 'asc', offset: 0, limit: 12,
       });
-      expect(rows.length).toBe(12);
-      expect(rows[0].activityRecipients[0].activityRecipientId).toBe(RECIPIENT_ID);
+      expect(rows.length).toBe(7);
+      expect(rows[0].activityRecipients[0].grantId).toBe(firstGrant.id);
     });
 
     it('retrieves reports sorted by sorted topics', async () => {
-      reportObject.topics = ['topic d', 'topic c'];
       await ActivityReport.create(reportObject);
-      reportObject.topics = ['topic b', 'topic a'];
       await ActivityReport.create(reportObject);
 
       const { rows } = await activityReports([1, 2], {
         sortBy: 'topics', sortDir: 'asc', offset: 0, limit: 12,
       });
-      expect(rows.length).toBe(12);
+      expect(rows.length).toBe(7);
       expect(rows[0].sortedTopics[0]).toBe('topic a');
       expect(rows[0].sortedTopics[1]).toBe('topic b');
       expect(rows[1].sortedTopics[0]).toBe('topic c');
@@ -376,11 +412,6 @@ describe('Activity Reports DB service', () => {
     });
 
     it('retrieves myalerts', async () => {
-      const mockUserTwo = {
-        id: 1002,
-        homeRegionId: 1,
-        name: 'a user',
-      };
       await User.findOrCreate({
         where: {
           id: mockUserTwo.id,

--- a/src/services/activityReports.test.js
+++ b/src/services/activityReports.test.js
@@ -27,6 +27,14 @@ const mockUser = {
   hsesUserId: '1000',
 };
 
+const mockUserTwo = {
+  id: 1002,
+  homeRegionId: 1,
+  name: 'a user',
+  hsesUserId: 50,
+  hsesUsername: 'Rex',
+};
+
 const reportObject = {
   activityRecipientType: 'grantee',
   status: REPORT_STATUSES.DRAFT,
@@ -73,7 +81,7 @@ describe('Activity Reports DB service', () => {
     await NextStep.destroy({ where: {} });
     await ActivityRecipient.destroy({ where: {} });
     await ActivityReport.destroy({ where: {} });
-    await User.destroy({ where: { id: mockUser.id } });
+    await User.destroy({ where: { id: [mockUser.id, mockUserTwo.id] } });
     await NonGrantee.destroy({ where: { id: RECIPIENT_ID } });
     await Grant.destroy({ where: { id: [RECIPIENT_ID, GRANTEE_ID] } });
     await Grantee.destroy({ where: { id: [RECIPIENT_ID, GRANTEE_ID] } });
@@ -296,14 +304,6 @@ describe('Activity Reports DB service', () => {
     let latestReport;
     let firstGrant;
 
-    const mockUserTwo = {
-      id: 1002,
-      homeRegionId: 1,
-      name: 'a user',
-      hsesUsername: 'user',
-      hsesUserId: '1002',
-    };
-
     beforeAll(async () => {
       const topicsOne = ['topic d', 'topic c'];
       const topicsTwo = ['topic b', 'topic a'];
@@ -412,14 +412,6 @@ describe('Activity Reports DB service', () => {
     });
 
     it('retrieves myalerts', async () => {
-      const mockUserTwo = {
-        id: 1002,
-        homeRegionId: 1,
-        name: 'a user',
-        hsesUserId: 50,
-        hsesUsername: 'Rex',
-      };
-
       await User.findOrCreate({
         where: {
           id: mockUserTwo.id,
@@ -430,8 +422,8 @@ describe('Activity Reports DB service', () => {
       await ActivityReport.create(reportObject);
 
       const { count, rows } = await activityReportAlerts(mockUserTwo.id, {});
-      expect(count).toBe(7);
-      expect(rows.length).toBe(7);
+      expect(count).toBe(5);
+      expect(rows.length).toBe(5);
       expect(rows[0].userId).toBe(mockUserTwo.id);
     });
   });


### PR DESCRIPTION
**Description of change**

The API call to populate the main reports table is now filtered to return only approved reports.

**How to test**
1) Pull down
2) Create a draft report
3) Login with another user with read permissions to the region of the report from step 2
4) Note the draft report does not show up in the list of reports
5) Submit and approve the report from step 2
6) Login with the user from step 3, the report shows up in the list of reports as `Approved`

**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/360

**Checklist**
<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] Code tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
