### PR TITLE
add region to s3 config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ parameters:
     default: "main"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
-    default: "cm-363-record-deployments"
+    default: "cm-370-downloading-files-does-not-work"
     type: string
   prod_new_relic_app_id:
     default: "877570491"

--- a/src/lib/s3.js
+++ b/src/lib/s3.js
@@ -9,6 +9,7 @@ const generateS3Config = () => {
       s3Config: {
         accessKeyId: credentials.access_key_id,
         endpoint: credentials.fips_endpoint,
+        region: credentials.region,
         secretAccessKey: credentials.secret_access_key,
         signatureVersion: 'v4',
         s3ForcePathStyle: true,


### PR DESCRIPTION
**Description of change**
The current version of the node aws sdk does not provide the presigned url call with the region, so it defaults to us-east-1 unless you specify a region in the s3 config. 

This PR adds a region to the config when running in cloud.gov.

**How to test**
Go to the sandbox, and upload a file. Then go to the review screen and try to download it.

**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/370

**Checklist**
<!-- Add details to each completed item -->
- [X] Meets issue criteria
- [X] Code tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
