### PR TITLE
Resources fix

### DIFF
--- a/frontend/src/components/FileUploader.js
+++ b/frontend/src/components/FileUploader.js
@@ -199,7 +199,7 @@ const FileTable = ({ onFileRemoved, files }) => {
               </td>
               <td>
                 <Button
-                  role="button"
+                  type="button"
                   className="smart-hub--file-tag-button"
                   unstyled
                   aria-label="remove file"

--- a/frontend/src/pages/ActivityReport/Pages/components/ResourceSelector.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/ResourceSelector.js
@@ -18,6 +18,15 @@ const ResourceSelector = ({ name, ariaName }) => {
 
   const canDelete = fields.length > 1;
 
+  const onAddNewResource = () => {
+    const allValues = getValues();
+    const fieldArray = allValues[name] || [];
+    const canAdd = fieldArray.every((field) => field.value !== '');
+    if (canAdd) {
+      append({ value: '' });
+    }
+  };
+
   return (
     <>
       {fields.map((item, index) => (
@@ -27,6 +36,11 @@ const ResourceSelector = ({ name, ariaName }) => {
             type="text"
             defaultValue={item.value}
             inputRef={register()}
+            onKeyUp={(e) => {
+              if (e.key === 'Enter') {
+                onAddNewResource();
+              }
+            }}
           />
           {canDelete && (
           <Button onClick={() => remove(index)} aria-label={`remove ${ariaName} ${index + 1}`} className="smart-hub--remove-resource" unstyled type="button">
@@ -38,14 +52,7 @@ const ResourceSelector = ({ name, ariaName }) => {
       <Button
         unstyled
         type="button"
-        onClick={() => {
-          const allValues = getValues();
-          const fieldArray = allValues[name] || [];
-          const canAdd = fieldArray.every((field) => field.value !== '');
-          if (canAdd) {
-            append({ value: '' });
-          }
-        }}
+        onClick={onAddNewResource}
       >
         <span className="fa-layers fa-fw">
           <FontAwesomeIcon color="#0166ab" size="lg" icon={faCircle} />

--- a/frontend/src/pages/ActivityReport/Pages/components/__tests__/ResourceSelector.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/__tests__/ResourceSelector.js
@@ -49,6 +49,16 @@ describe('ResourceSelector', () => {
     });
   });
 
+  describe('when enter is pressed', () => {
+    it('adds a new resource', async () => {
+      render(<RenderResourceSelector data={[{ value: '' }]} />);
+      const textBox = await screen.findByTestId('textInput');
+      userEvent.type(textBox, 'test{enter}');
+      const text = await screen.findAllByRole('textbox');
+      expect(text.length).toBe(2);
+    });
+  });
+
   describe('with multiple entries', () => {
     it('allows removal of an item', async () => {
       render(<RenderResourceSelector data={[{ value: 'first' }, { value: 'second' }]} />);

--- a/frontend/src/pages/ActivityReport/Pages/nextSteps.js
+++ b/frontend/src/pages/ActivityReport/Pages/nextSteps.js
@@ -145,7 +145,7 @@ const NoteEntries = ({ name, humanName }) => {
           </div>
         )
           : (
-            <Button unstyled onClick={() => onEdit(notes.length)}>
+            <Button type="button" unstyled onClick={() => onEdit(notes.length)}>
               <FontAwesomeIcon icon={faPlusCircle} />
               <span className="padding-left-05">Add New Follow Up</span>
             </Button>

--- a/frontend/src/pages/ActivityReport/index.js
+++ b/frontend/src/pages/ActivityReport/index.js
@@ -95,6 +95,12 @@ function ActivityReport({
     return array.map((value) => ({ value }));
   };
 
+  const convertReportToFormData = (fetchedReport) => {
+    const ECLKCResourcesUsed = unflattenResourcesUsed(fetchedReport.ECLKCResourcesUsed);
+    const nonECLKCResourcesUsed = unflattenResourcesUsed(fetchedReport.nonECLKCResourcesUsed);
+    return { ...fetchedReport, ECLKCResourcesUsed, nonECLKCResourcesUsed };
+  };
+
   useDeepCompareEffect(() => {
     const fetch = async () => {
       let report;
@@ -103,9 +109,7 @@ function ActivityReport({
         updateLoading(true);
         if (activityReportId !== 'new') {
           const fetchedReport = await getReport(activityReportId);
-          const ECLKCResourcesUsed = unflattenResourcesUsed(fetchedReport.ECLKCResourcesUsed);
-          const nonECLKCResourcesUsed = unflattenResourcesUsed(fetchedReport.nonECLKCResourcesUsed);
-          report = { ...fetchedReport, ECLKCResourcesUsed, nonECLKCResourcesUsed };
+          report = convertReportToFormData(fetchedReport);
         } else {
           report = {
             ...defaultValues,
@@ -213,18 +217,21 @@ function ActivityReport({
   };
 
   const onFormSubmit = async (data) => {
-    const report = await submitReport(reportId.current, data);
+    const fetchedReport = await submitReport(reportId.current, data);
+    const report = convertReportToFormData(fetchedReport);
     updateFormData(report);
     updateEditable(false);
   };
 
   const onReview = async (data) => {
-    const report = await reviewReport(reportId.current, data);
+    const fetchedReport = await reviewReport(reportId.current, data);
+    const report = convertReportToFormData(fetchedReport);
     updateFormData(report);
   };
 
   const onResetToDraft = async () => {
-    const report = await resetToDraft(reportId.current);
+    const fetchedReport = await resetToDraft(reportId.current);
+    const report = convertReportToFormData(fetchedReport);
     updateFormData(report);
     updateEditable(true);
   };

--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -488,18 +488,22 @@ export async function createOrUpdate(newActivityReport, report) {
     author,
     granteeNextSteps,
     specialistNextSteps,
+    ECLKCResourcesUsed,
+    nonECLKCResourcesUsed,
     ...allFields
   } = newActivityReport;
 
-  const ECLKCResourcesUsed = allFields.ECLKCResourcesUsed
-    ? allFields.ECLKCResourcesUsed.map((item) => item.value)
-    : [];
+  const resources = {};
 
-  const nonECLKCResourcesUsed = allFields.nonECLKCResourcesUsed
-    ? allFields.nonECLKCResourcesUsed.map((item) => item.value)
-    : [];
+  if (ECLKCResourcesUsed) {
+    resources.ECLKCResourcesUsed = ECLKCResourcesUsed.map((item) => item.value);
+  }
 
-  const updatedFields = { ...allFields, ECLKCResourcesUsed, nonECLKCResourcesUsed };
+  if (nonECLKCResourcesUsed) {
+    resources.nonECLKCResourcesUsed = nonECLKCResourcesUsed.map((item) => item.value);
+  }
+
+  const updatedFields = { ...allFields, ...resources };
   await sequelize.transaction(async (transaction) => {
     if (report) {
       savedReport = await update(updatedFields, report, transaction);


### PR DESCRIPTION
**Description of change**
* Pressing enter in a resource textbox now adds that resource and does not open the file delete dialog
* Resources are only updated on the server when passed to the API, previously if they were not included in the API call they would be set to empty
* The frontend properly sets the report in the format needed by react-hook-form when setting formData, previously this was only done on the initial load. This solves an issue resetting drafts to normal and having resources disappear

**How to test**
Pull down, create a report

**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/386

**Checklist**
<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [ ] Code tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
