### PR TITLE
Display next steps input box in same line

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/nextSteps.js
+++ b/frontend/src/pages/ActivityReport/Pages/nextSteps.js
@@ -132,7 +132,7 @@ const NoteEntries = ({ name, humanName, label }) => {
               return prompt;
             }
             return (
-              <li key={item.note} className="grid-row flex-row border-bottom padding-top-2 padding-bottom-2" style={{ borderColor: '#f0f0f0' }}>
+              <li key={item.note + index.toString()} className="grid-row flex-row border-bottom padding-top-2 padding-bottom-2" style={{ borderColor: '#f0f0f0' }}>
                 <div className="grid-col flex-12">
                   {item.note}
                 </div>

--- a/frontend/src/pages/ActivityReport/Pages/nextSteps.js
+++ b/frontend/src/pages/ActivityReport/Pages/nextSteps.js
@@ -107,43 +107,50 @@ const NoteEntries = ({ name, humanName }) => {
   const targetId = notes[targetIndex] ? notes[targetIndex].id : undefined;
   const defaultValue = notes[targetIndex] ? notes[targetIndex].note : undefined;
 
+  const prompt = (
+    <div className="border-left-05 border-blue padding-left-2 margin-top-2 smart-hub-border-blue-primary">
+      <NoteEntry
+        onEntry={(value) => onEntry(value, targetIndex, targetId)}
+        isRequired={false}
+        onCancel={onCancel}
+        name={name}
+        humanName={humanName}
+        defaultValue={defaultValue}
+      />
+    </div>
+  );
+
   return (
     <>
       <Fieldset className="smart-hub--report-legend smart-hub--form-section" legend={`${humanName} Next Steps`}>
         <ul className="usa-list--unstyled">
-          {notes.map((item, index) => (
-            <li key={item.note} className="grid-row flex-row border-bottom padding-top-2 padding-bottom-2" style={{ borderColor: '#f0f0f0' }}>
-              <div className="grid-col flex-12">
-                {item.note}
-              </div>
+          {notes.map((item, index) => {
+            if (showPrompt && (index === targetIndex)) {
+              return prompt;
+            }
+            return (
+              <li key={item.note} className="grid-row flex-row border-bottom padding-top-2 padding-bottom-2" style={{ borderColor: '#f0f0f0' }}>
+                <div className="grid-col flex-12">
+                  {item.note}
+                </div>
 
-              <div className="grid-col" style={{ marginTop: '0px' }}>
-                <ContextMenu
-                  label="Actions menu"
-                  menuItems={
-                    [
-                      { label: 'Edit', onClick: () => { onEdit(index); } },
-                      { label: 'Delete', onClick: () => { onDelete(index); } },
-                    ]
-                  }
-                />
-              </div>
-            </li>
-          ))}
+                <div className="grid-col" style={{ marginTop: '0px' }}>
+                  <ContextMenu
+                    label="Actions menu"
+                    menuItems={
+                      [
+                        { label: 'Edit', onClick: () => { onEdit(index); } },
+                        { label: 'Delete', onClick: () => { onDelete(index); } },
+                      ]
+                    }
+                  />
+                </div>
+              </li>
+            );
+          })}
         </ul>
 
-        {showPrompt ? (
-          <div className="border-left-05 border-blue padding-left-2 margin-top-2 smart-hub-border-blue-primary">
-            <NoteEntry
-              onEntry={(value) => onEntry(value, targetIndex, targetId)}
-              isRequired={false}
-              onCancel={onCancel}
-              name={name}
-              humanName={humanName}
-              defaultValue={defaultValue}
-            />
-          </div>
-        )
+        {showPrompt && targetIndex >= notes.length ? prompt
           : (
             <Button type="button" unstyled onClick={() => onEdit(notes.length)}>
               <FontAwesomeIcon icon={faPlusCircle} />

--- a/frontend/src/pages/ActivityReport/Pages/nextSteps.js
+++ b/frontend/src/pages/ActivityReport/Pages/nextSteps.js
@@ -153,14 +153,14 @@ const NoteEntries = ({ name, humanName, label }) => {
           })}
         </ul>
 
-        {showPrompt && targetIndex >= notes.length ?
-         prompt
-         : (
-           <Button type="button" unstyled onClick={() => onEdit(notes.length)}>
-             <FontAwesomeIcon icon={faPlusCircle} />
-             <span className="padding-left-05">Add New Next Step</span>
-           </Button>
-         )}
+        {showPrompt && targetIndex >= notes.length
+          ? prompt
+          : (
+            <Button type="button" unstyled onClick={() => onEdit(notes.length)}>
+              <FontAwesomeIcon icon={faPlusCircle} />
+              <span className="padding-left-05">Add New Next Step</span>
+            </Button>
+          )}
 
       </Fieldset>
     </>


### PR DESCRIPTION
**Description of change**
In the Next Steps page, allow a user to edit their entry in-place instead of allowing them to edit the entry in the bottom of the list

**How to test**
Pull down changes
Start/edit a report and go to next steps
Once you enter a few items, you can select "Edit" from context menu.
You should be able to edit the entry right there

**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/397

**Checklist**
<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] Code tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
