### PR TITLE
Printing fixes for chrome

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -105,6 +105,10 @@ body {
     width: 100%;
   }
 
+  .smart-hub-review-section {
+    page-break-inside: avoid;
+  }
+
   .print\:grid-col-6 {
     flex: 0 1 auto;
     width: 50%;
@@ -202,7 +206,6 @@ body {
     break-before: avoid-page;
     break-after: auto;
     display: block;
-    margin-bottom: 0.5in;
     padding: 0;
   }
 

--- a/frontend/src/pages/ActivityReport/Pages/Review/ReviewSection.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/ReviewSection.js
@@ -9,7 +9,7 @@ const Section = ({
     'smart-hub-review-section',
     'margin-top-2 desktop:margin-top-0',
     hidePrint ? 'smart-hub-review-section--empty no-print' : '',
-    'margin-bottom-3',
+    'padding-bottom-3',
   ].filter((x) => x).join(' ');
 
   return (


### PR DESCRIPTION
**Description of change**

 * Change review item margin to padding, chrome seems to ignore the margin around page breaks
 * Help out printing page breaks by avoiding breaks in `ReviewSections`

**How to test**

Pull down. Change `frontend/src/pages/ActivityReport/Pages/Review/ReviewSection.js` line 12 to `margin-bottom-3` Create a report. Look for cut off text around the page breaks when printing. Once you find one change line 12 back to `padding-bottom-3` and try to print again. The text should no longer be cut off.

**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/394

**Checklist**
<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] Code tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
