### PR TITLE
Prevent legacy scripts from deploying

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -4,6 +4,7 @@ deployment_config/
 frontend/
 src/
 maintenance_page/
+smartsheet_scripts/
 terraform/
 hses.zip
 temp/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,7 @@ parameters:
     default: "main"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
-    default: "kw-ie-keyboard-nav"
+    default: "cfignore-legacy-scripts"
     type: string
   prod_new_relic_app_id:
     default: "877570491"


### PR DESCRIPTION
**Description of change**

* Don't deploy the legacy scripts code to cloud.gov. It's not meant to be run there.

**How to test**

* ssh into sandbox, verify that smartsheet_scripts folder is not present.

**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/62

**Checklist**
<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] Code tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [x] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
