### PR TITLE
Remove early exit from reconcile CLI script

### DIFF
--- a/src/services/legacyreports.js
+++ b/src/services/legacyreports.js
@@ -144,5 +144,6 @@ export default async function reconcileLegacyReports() {
     await Promise.all(updates);
   } catch (err) {
     logger.error(err);
+    throw err;
   }
 }

--- a/src/tools/reconcileLegacyReports.js
+++ b/src/tools/reconcileLegacyReports.js
@@ -1,7 +1,7 @@
 import reconcileLegacyReports from '../services/legacyreports';
 import { auditLogger } from '../logger';
 
-reconcileLegacyReports().then(process.exit(0)).catch((e) => {
+reconcileLegacyReports().catch((e) => {
   auditLogger.error(e);
   process.exit(1);
 });


### PR DESCRIPTION
**Description of change**

Remove accidental call to `process.exit(0)` before the script really got started.

**How to test**

`yarn reconcile:legacy:local` should run and not exit immediately.


**Issue(s)**
* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-71

**Checklist**
<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] Code tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [x] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
