### PR TITLE
Screen reader update

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/__tests__/nextSteps.js
+++ b/frontend/src/pages/ActivityReport/Pages/__tests__/nextSteps.js
@@ -12,7 +12,7 @@ const SPECIALIST_INPUT = 'specialistNextSteps-input';
 const SPECIALIST_BUTTON = 'specialistNextSteps-button';
 const SPECIALIST_CANCEL_BUTTON = 'specialistNextSteps-cancel-button';
 
-const GRANTEE_NEXT_STEPS = 'Grantees Next Steps';
+const GRANTEE_NEXT_STEPS = "Grantee's Next Steps";
 const GRANTEE_INPUT = 'granteeNextSteps-input';
 const GRANTEE_BUTTON = 'granteeNextSteps-button';
 const GRANTEE_CANCEL_BUTTON = 'granteeNextSteps-cancel-button';

--- a/frontend/src/pages/ActivityReport/Pages/nextSteps.js
+++ b/frontend/src/pages/ActivityReport/Pages/nextSteps.js
@@ -190,7 +190,7 @@ const NextSteps = () => (
       <NoteEntries name="specialistNextSteps" humanName="Specialist" label="What have you agreed to do next?" />
     </div>
 
-    <NoteEntries name="granteeNextSteps" humanName="Grantees" label="What has the grantee agreed to do next?" />
+    <NoteEntries name="granteeNextSteps" humanName="Grantee's" label="What has the grantee agreed to do next?" />
 
   </>
 );

--- a/frontend/src/pages/ActivityReport/Pages/nextSteps.js
+++ b/frontend/src/pages/ActivityReport/Pages/nextSteps.js
@@ -159,12 +159,12 @@ const NoteEntries = ({ name, humanName, label }) => {
             <Button type="button" unstyled onClick={() => onEdit(notes.length)}>
               <FontAwesomeIcon icon={faPlusCircle} />
               <span className="padding-left-05">
-                Add New Next
+                Add New
                 {' '}
                 <span className="usa-sr-only">
                   {humanName}
                 </span>
-                Step
+                Next Step
               </span>
             </Button>
           )}

--- a/frontend/src/pages/ActivityReport/Pages/nextSteps.js
+++ b/frontend/src/pages/ActivityReport/Pages/nextSteps.js
@@ -158,7 +158,14 @@ const NoteEntries = ({ name, humanName, label }) => {
           : (
             <Button type="button" unstyled onClick={() => onEdit(notes.length)}>
               <FontAwesomeIcon icon={faPlusCircle} />
-              <span className="padding-left-05">Add New Next Step</span>
+              <span className="padding-left-05">
+                Add New Next
+                {' '}
+                <span className="usa-sr-only">
+                  {humanName}
+                </span>
+                Step
+              </span>
             </Button>
           )}
 


### PR DESCRIPTION
**Description of change**
When using a screen reader, the "add new entry button" is not read as "add new X entry" where X is Specialist or Grantee. Giving more context.

**How to test**
Pull down changes, run locally and navigate to the next steps page with screen reader.

**Issue(s)**
* https://ocio-jira.acf.hhs.gov/projects/TTAHUB/issues/TTAHUB-57

**Checklist**
<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] Code tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
