### PR TITLE
ignore legacy reports in my alerts

### DIFF
--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -415,6 +415,7 @@ export function activityReportAlerts(userId, {
           ],
         },
       ],
+      legacyId: null,
     },
     attributes: [
       'id',


### PR DESCRIPTION
**Description of change**
Legacy reports that were imported with a submitted status are showing up in the My Alerts sections, but will not display correctly so are kicking users out or are showing blank screens.

This PR makes sure that legacy reports will not show up in the My Alerts section.

Reference: https://gsa-tts.slack.com/archives/C017RJ4GEET/p1617392158040400?thread_ts=1617388889.033500&cid=C017RJ4GEET

**How to test**
Pull down changes
Create an activity report and submit it with yourself as the approving manager.
Edit the DB record for the activity report to add a legacyId
Make sure the activity report no longer shows up in the alerts

**Issue(s)**
https://ocio-jira.acf.hhs.gov/browse/TTAHUB-91

**Checklist**
<!-- Add details to each completed item -->
- [X] Meets issue criteria
- [ ] Code tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
