### PR TITLE
update ECLKC link in help text to open in a new tab

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/topicsResources.js
+++ b/frontend/src/pages/ActivityReport/Pages/topicsResources.js
@@ -54,7 +54,7 @@ const TopicsResources = ({
             <br />
             Enter the URL for OHS resource(s) used.
             {' '}
-            <a href="https://eclkc.ohs.acf.hhs.gov/">https://eclkc.ohs.acf.hhs.gov/</a>
+            <a target="_blank" rel="noreferrer" href="https://eclkc.ohs.acf.hhs.gov/">https://eclkc.ohs.acf.hhs.gov/</a>
             <ResourceSelector
               name="ECLKCResourcesUsed"
               ariaName="ECLKC Resources"

--- a/frontend/src/pages/ActivityReport/Pages/topicsResources.js
+++ b/frontend/src/pages/ActivityReport/Pages/topicsResources.js
@@ -54,7 +54,8 @@ const TopicsResources = ({
             <br />
             Enter the URL for OHS resource(s) used.
             {' '}
-            <a target="_blank" rel="noreferrer" href="https://eclkc.ohs.acf.hhs.gov/">https://eclkc.ohs.acf.hhs.gov/</a>
+            {/* eslint-disable-next-line react/jsx-no-target-blank */}
+            <a target="_blank" rel="noopener" href="https://eclkc.ohs.acf.hhs.gov/">https://eclkc.ohs.acf.hhs.gov/</a>
             <ResourceSelector
               name="ECLKCResourcesUsed"
               ariaName="ECLKC Resources"


### PR DESCRIPTION
**Description of change**
add `target="_blank" to eclkc help text link on topics and resources page

**How to test**
pull down changes
click on eclkc link
It should open in a new tab

**Issue(s)**
* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-94

**Checklist**
<!-- Add details to each completed item -->
- [X] Meets issue criteria
- [X] Code tested
- [X] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [X] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
