### PR TITLE
Update approved smartsheet reports on re-import

### DIFF
--- a/src/tools/importActivityReports.test.js
+++ b/src/tools/importActivityReports.test.js
@@ -50,7 +50,10 @@ describe('Import Activity Reports', () => {
     downloadFile.mockResolvedValue({ Body: readFileSync(fileName) });
 
     const legacyId = 'R14-AR-001132';
-    await ActivityReport.create({ legacyId, status: REPORT_STATUSES.SUBMITTED }, { validate: false });
+    const legacyReport = await ActivityReport.create({
+      legacyId,
+      status: REPORT_STATUSES.SUBMITTED,
+    }, { validate: false });
     await importActivityReports(fileName, 14);
 
     const records = await ActivityReport.findAll({
@@ -61,8 +64,7 @@ describe('Import Activity Reports', () => {
     });
     expect(records).toBeDefined();
     expect(records).toContainEqual(
-      expect.objectContaining({ id: expect.anything(), legacyId, status: REPORT_STATUSES.APPROVED }),
+      expect.objectContaining({ id: legacyReport.id, legacyId, status: REPORT_STATUSES.APPROVED }),
     );
-
   });
 });

--- a/src/tools/importSSActivityReports.js
+++ b/src/tools/importSSActivityReports.js
@@ -1,7 +1,7 @@
 import {} from 'dotenv/config';
 import { option } from 'yargs';
 import importActivityReports from './importActivityReports';
-import { logger } from '../logger';
+import { auditLogger as logger } from '../logger';
 
 const { argv } = option('file', {
   alias: 'f',
@@ -26,4 +26,7 @@ if (!region) {
   process.exit(1);
 }
 
-importActivityReports(file, region);
+importActivityReports(file, region).catch((e) => {
+  logger.error(e);
+  return process.exit(1);
+});


### PR DESCRIPTION
**Description of change**

* Update legacy activity reports on the second import

**How to test**

There is a new unit test that verifies the behavior.

**Issue(s)**
* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-61

**Checklist**
<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [x] Code tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [x] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
