### PR TITLE
[TTAHUB-89]: Frontend for downloading reports

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -154,6 +154,9 @@
         "functions": 90,
         "branches": 90,
         "lines": 90
+      },
+      "./src/pages/Landing/index.js": {
+        "branches": 85
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -154,9 +154,6 @@
         "functions": 90,
         "branches": 90,
         "lines": 90
-      },
-      "./src/pages/Landing/index.js": {
-        "branches": 85
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -145,7 +145,8 @@
   "jest": {
     "coveragePathIgnorePatterns": [
       "<rootDir>/src/index.js",
-      "<rootDir>/src/setupProxy.js"
+      "<rootDir>/src/setupProxy.js",
+      "<rootDir>/src/pages/NotFound/index.js"
     ],
     "coverageThreshold": {
       "global": {

--- a/frontend/src/fetchers/__tests__/helpers.js
+++ b/frontend/src/fetchers/__tests__/helpers.js
@@ -1,0 +1,20 @@
+import { getReportsDownloadURL } from '../helpers';
+
+describe('getReportsDownloadURL', () => {
+  it('Creates a URL for downloading a single report', () => {
+    const dlURL = getReportsDownloadURL([1]);
+    expect(dlURL).toMatch('report[]=1');
+  });
+
+  it('Creates a URL for downloading multiple reports', () => {
+    const dlURL = getReportsDownloadURL([1, 23, 42]);
+    expect(dlURL).toMatch('report[]=1');
+    expect(dlURL).toMatch('report[]=23');
+    expect(dlURL).toMatch('report[]=42');
+  });
+
+  it('Ouputs no report query params if no reports provided', () => {
+    const dlURL = getReportsDownloadURL([]);
+    expect(dlURL).not.toMatch('report[]=');
+  });
+});

--- a/frontend/src/fetchers/activityReports.js
+++ b/frontend/src/fetchers/activityReports.js
@@ -75,9 +75,3 @@ export const resetToDraft = async (reportId) => {
   const response = await put(url);
   return response.json();
 };
-
-export const getReportsDownloadURL = (reportIds) => {
-  const reportsQuery = reportIds.map((i) => `report[]=${i}`);
-  const queryItems = ['?format=csv', ...reportsQuery];
-  return join(activityReportUrl, 'download', queryItems.join('&'));
-};

--- a/frontend/src/fetchers/activityReports.js
+++ b/frontend/src/fetchers/activityReports.js
@@ -75,3 +75,9 @@ export const resetToDraft = async (reportId) => {
   const response = await put(url);
   return response.json();
 };
+
+export const getReportsDownloadURL = (reportIds) => {
+  const reportsQuery = reportIds.map((i) => `report[]=${i}`);
+  const queryItems = ['?format=csv', ...reportsQuery];
+  return join(activityReportUrl, 'download', queryItems.join('&'));
+};

--- a/frontend/src/fetchers/helpers.js
+++ b/frontend/src/fetchers/helpers.js
@@ -1,0 +1,13 @@
+import join from 'url-join';
+
+const getReportsDownloadURL = (reportIds) => {
+  const activityReportUrl = join('/', 'api', 'activity-reports');
+  const reportsQuery = reportIds.map((i) => `report[]=${i}`);
+  const queryItems = ['?format=csv', ...reportsQuery];
+  return join(activityReportUrl, 'download', queryItems.join('&'));
+};
+
+export {
+  getReportsDownloadURL as default,
+  getReportsDownloadURL,
+};

--- a/frontend/src/pages/Landing/__tests__/index.js
+++ b/frontend/src/pages/Landing/__tests__/index.js
@@ -384,6 +384,46 @@ describe('Landing Page sorting', () => {
 });
 
 describe('Landing page table menus & selections', () => {
+  describe('Table row checkboxes', () => {
+    afterEach(() => fetchMock.restore());
+
+    beforeEach(async () => {
+      fetchMock.reset();
+      fetchMock.get('/api/activity-reports/alerts?sortBy=startDate&sortDir=desc&offset=0&limit=10',
+        { alertsCount: 0, alerts: [] });
+      fetchMock.get(
+        '/api/activity-reports?sortBy=updatedAt&sortDir=desc&offset=0&limit=10',
+        { count: 10, rows: generateXFakeReports(10) },
+      );
+      const user = {
+        name: 'test@test.com',
+        permissions: [
+          {
+            scopeId: 3,
+            regionId: 1,
+          },
+        ],
+      };
+
+      renderLanding(user);
+      await screen.findByText('Activity Reports');
+    });
+
+    it('Can select and deselect a single checkbox', async () => {
+      const reportCheckboxes = await screen.findAllByRole('checkbox', { name: /select /i });
+
+      // Element 0 is 'Select all', so we want 1 or later
+      const singleReportCheck = reportCheckboxes[1];
+      expect(singleReportCheck.value).toEqual('1');
+
+      fireEvent.click(singleReportCheck);
+      expect(singleReportCheck.checked).toBe(true);
+
+      fireEvent.click(singleReportCheck);
+      expect(singleReportCheck.checked).toBe(false);
+    });
+  });
+
   describe('Table header checkbox', () => {
     afterEach(() => fetchMock.restore());
 

--- a/frontend/src/pages/Landing/__tests__/index.js
+++ b/frontend/src/pages/Landing/__tests__/index.js
@@ -378,6 +378,72 @@ describe('Landing Page sorting', () => {
   });
 });
 
+describe('Landing page table menus & selections', () => {
+  describe('Table header checkbox', () => {
+    afterEach(() => fetchMock.restore());
+
+    beforeEach(async () => {
+      fetchMock.reset();
+      fetchMock.get('/api/activity-reports/alerts?sortBy=startDate&sortDir=desc&offset=0&limit=10',
+        { alertsCount: 0, alerts: [] });
+      fetchMock.get(
+        '/api/activity-reports?sortBy=updatedAt&sortDir=desc&offset=0&limit=10',
+        { count: 17, rows: generateXFakeReports(10) },
+      );
+      const user = {
+        name: 'test@test.com',
+        permissions: [
+          {
+            scopeId: 3,
+            regionId: 1,
+          },
+        ],
+      };
+
+      renderLanding(user);
+      await screen.findByText('Activity Reports');
+    });
+
+    it('Selects all reports when checked', async () => {
+      const selectAllCheckbox = await screen.findByLabelText(/select or de-select all reports/i);
+
+      fireEvent.click(selectAllCheckbox);
+
+      await waitFor(() => {
+        const checkboxes = screen.getAllByRole('checkbox');
+        expect(checkboxes).toHaveLength(11); // 1 selectAllCheckbox + 10 report checkboxes
+        checkboxes.forEach((c) => expect(c).toBeChecked());
+      });
+    });
+
+    it('De-selects all reports if all are already selected', async () => {
+      const selectAllCheckbox = await screen.findByLabelText(/select or de-select all reports/i);
+
+      fireEvent.click(selectAllCheckbox);
+
+      await waitFor(() => {
+        const checkboxes = screen.getAllByRole('checkbox');
+        expect(checkboxes).toHaveLength(11); // 1 selectAllCheckbox + 10 report checkboxes
+        checkboxes.forEach((c) => expect(c).toBeChecked());
+      });
+
+      fireEvent.click(selectAllCheckbox);
+
+      await waitFor(() => {
+        const checkboxes = screen.getAllByRole('checkbox');
+        expect(checkboxes).toHaveLength(11); // 1 selectAllCheckbox + 10 report checkboxes
+        checkboxes.forEach((c) => expect(c).not.toBeChecked());
+      });
+    });
+  });
+
+  describe('Tablewide Context Menu', () => {
+    test.todo('Download a single report');
+    test.todo('Download multiple reports');
+    test.todo('Legacy reports do not download');
+  });
+});
+
 describe('My alerts sorting', () => {
   afterEach(() => fetchMock.restore());
 

--- a/frontend/src/pages/Landing/__tests__/index.js
+++ b/frontend/src/pages/Landing/__tests__/index.js
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import React from 'react';
 import {
-  render, screen, fireEvent, waitFor, waitForElementToBeRemoved,
+  render, screen, fireEvent, waitFor,
 } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import fetchMock from 'fetch-mock';

--- a/frontend/src/pages/Landing/__tests__/index.js
+++ b/frontend/src/pages/Landing/__tests__/index.js
@@ -154,7 +154,7 @@ describe('Landing Page', () => {
 
   test('displays the options buttons', async () => {
     const optionButtons = await screen.findAllByRole('button', {
-      name: /view activity report r14-ar-2/i,
+      name: /actions for activity report r14-ar-2/i,
     });
 
     expect(optionButtons.length).toBe(1);
@@ -202,8 +202,8 @@ describe('Landing Page sorting', () => {
     );
 
     fireEvent.click(statusColumnHeader);
-    await waitFor(() => expect(screen.getAllByRole('cell')[6]).toHaveTextContent(/needs action/i));
-    await waitFor(() => expect(screen.getAllByRole('cell')[14]).toHaveTextContent(/draft/i));
+    await waitFor(() => expect(screen.getAllByRole('cell')[7]).toHaveTextContent(/needs action/i));
+    await waitFor(() => expect(screen.getAllByRole('cell')[16]).toHaveTextContent(/draft/i));
 
     fetchMock.get(
       '/api/activity-reports?sortBy=status&sortDir=desc&offset=0&limit=10',
@@ -211,8 +211,8 @@ describe('Landing Page sorting', () => {
     );
 
     fireEvent.click(statusColumnHeader);
-    await waitFor(() => expect(screen.getAllByRole('cell')[6]).toHaveTextContent(/draft/i));
-    await waitFor(() => expect(screen.getAllByRole('cell')[14]).toHaveTextContent(/needs action/i));
+    await waitFor(() => expect(screen.getAllByRole('cell')[7]).toHaveTextContent(/draft/i));
+    await waitFor(() => expect(screen.getAllByRole('cell')[16]).toHaveTextContent(/needs action/i));
   });
 
   it('clicking Last saved column header will sort by updatedAt', async () => {
@@ -224,8 +224,8 @@ describe('Landing Page sorting', () => {
     );
 
     fireEvent.click(columnHeader);
-    await waitFor(() => expect(screen.getAllByRole('cell')[5]).toHaveTextContent(/02\/04\/2021/i));
-    await waitFor(() => expect(screen.getAllByRole('cell')[13]).toHaveTextContent(/02\/05\/2021/i));
+    await waitFor(() => expect(screen.getAllByRole('cell')[6]).toHaveTextContent(/02\/04\/2021/i));
+    await waitFor(() => expect(screen.getAllByRole('cell')[15]).toHaveTextContent(/02\/05\/2021/i));
   });
 
   it('clicking Collaborators column header will sort by collaborators', async () => {
@@ -237,8 +237,8 @@ describe('Landing Page sorting', () => {
     );
 
     fireEvent.click(columnHeader);
-    await waitFor(() => expect(screen.getAllByRole('cell')[4]).toHaveTextContent('Cucumber User, GSHermione Granger, SS'));
-    await waitFor(() => expect(screen.getAllByRole('cell')[12]).toHaveTextContent('Orange, GSHermione Granger, SS'));
+    await waitFor(() => expect(screen.getAllByRole('cell')[5]).toHaveTextContent('Cucumber User, GSHermione Granger, SS'));
+    await waitFor(() => expect(screen.getAllByRole('cell')[14]).toHaveTextContent('Orange, GSHermione Granger, SS'));
   });
 
   it('clicking Topics column header will sort by topics', async () => {
@@ -250,8 +250,8 @@ describe('Landing Page sorting', () => {
     );
 
     fireEvent.click(columnHeader);
-    await waitFor(() => expect(screen.getAllByRole('cell')[3]).toHaveTextContent(''));
-    await waitFor(() => expect(screen.getAllByRole('cell')[11]).toHaveTextContent('Behavioral / Mental HealthCLASS: Instructional Support'));
+    await waitFor(() => expect(screen.getAllByRole('cell')[4]).toHaveTextContent(''));
+    await waitFor(() => expect(screen.getAllByRole('cell')[13]).toHaveTextContent('Behavioral / Mental HealthCLASS: Instructional Support'));
   });
 
   it('clicking Creator column header will sort by author', async () => {
@@ -263,8 +263,8 @@ describe('Landing Page sorting', () => {
     );
 
     fireEvent.click(columnHeader);
-    await waitFor(() => expect(screen.getAllByRole('cell')[2]).toHaveTextContent('Kiwi, GS'));
-    await waitFor(() => expect(screen.getAllByRole('cell')[10]).toHaveTextContent('Kiwi, TTAC'));
+    await waitFor(() => expect(screen.getAllByRole('cell')[3]).toHaveTextContent('Kiwi, GS'));
+    await waitFor(() => expect(screen.getAllByRole('cell')[12]).toHaveTextContent('Kiwi, TTAC'));
   });
 
   it('clicking Start date column header will sort by start date', async () => {
@@ -276,8 +276,8 @@ describe('Landing Page sorting', () => {
     );
 
     fireEvent.click(columnHeader);
-    await waitFor(() => expect(screen.getAllByRole('cell')[1]).toHaveTextContent('02/01/2021'));
-    await waitFor(() => expect(screen.getAllByRole('cell')[9]).toHaveTextContent('02/08/2021'));
+    await waitFor(() => expect(screen.getAllByRole('cell')[2]).toHaveTextContent('02/01/2021'));
+    await waitFor(() => expect(screen.getAllByRole('cell')[11]).toHaveTextContent('02/08/2021'));
   });
 
   it('clicking Grantee column header will sort by grantee', async () => {
@@ -291,7 +291,7 @@ describe('Landing Page sorting', () => {
     );
 
     fireEvent.click(columnHeader);
-    await waitFor(() => expect(screen.getAllByRole('cell')[0]).toHaveTextContent('Johnston-RomagueraJohnston-RomagueraGrantee Name'));
+    await waitFor(() => expect(screen.getAllByRole('cell')[1]).toHaveTextContent('Johnston-RomagueraJohnston-RomagueraGrantee Name'));
   });
 
   it('clicking Report id column header will sort by region and id', async () => {
@@ -336,8 +336,8 @@ describe('Landing Page sorting', () => {
     );
 
     fireEvent.click(pageOne);
-    await waitFor(() => expect(screen.getAllByRole('cell')[5]).toHaveTextContent(/02\/05\/2021/i));
-    await waitFor(() => expect(screen.getAllByRole('cell')[13]).toHaveTextContent(/02\/04\/2021/i));
+    await waitFor(() => expect(screen.getAllByRole('cell')[6]).toHaveTextContent(/02\/05\/2021/i));
+    await waitFor(() => expect(screen.getAllByRole('cell')[15]).toHaveTextContent(/02\/04\/2021/i));
   });
 
   it('clicking on the second page updates to, from and total', async () => {
@@ -555,8 +555,8 @@ describe('Landing Page error', () => {
     };
     renderLanding(user);
     const rowCells = await screen.findAllByRole('cell');
-    expect(rowCells.length).toBe(8);
-    const grantee = rowCells[0];
+    expect(rowCells.length).toBe(9);
+    const grantee = rowCells[1];
     expect(grantee).toHaveTextContent('');
   });
 

--- a/frontend/src/pages/Landing/index.css
+++ b/frontend/src/pages/Landing/index.css
@@ -2,7 +2,7 @@
   max-width: fit-content;
   font-family: 'Merriweather', serif;
 }
-  
+
 .pagination {
   float: right;
   white-space: nowrap;
@@ -110,12 +110,7 @@ h1.landing {
   border-color: #ECEEF1;
   border-bottom: none;
   cursor: pointer;
-  min-width: 90px;
   padding-right: 0px;
-}
-
-.landing .usa-table--borderless th:first-child {
-  padding-left: 20px;
 }
 
 .landing .usa-table td {

--- a/frontend/src/pages/Landing/index.js
+++ b/frontend/src/pages/Landing/index.js
@@ -14,7 +14,7 @@ import Pagination from 'react-js-pagination';
 
 import UserContext from '../../UserContext';
 import Container from '../../components/Container';
-import { getReports, getReportAlerts } from '../../fetchers/activityReports';
+import { getReports, getReportAlerts, getReportsDownloadURL } from '../../fetchers/activityReports';
 import NewReport from './NewReport';
 import 'uswds/dist/css/uswds.css';
 import '@trussworks/react-uswds/lib/index.css';
@@ -104,6 +104,15 @@ function renderReports(reports, history) {
         onClick: () => { history.push(linkTarget); },
       },
     ];
+
+    if (!legacyId) {
+      const downloadMenuItem = {
+        label: 'Download',
+        onClick: () => { document.location = getReportsDownloadURL([id]); },
+      };
+      menuItems.push(downloadMenuItem);
+    }
+
     const contextMenuLabel = `View activity report ${displayId}`;
 
     return (

--- a/frontend/src/pages/Landing/index.js
+++ b/frontend/src/pages/Landing/index.js
@@ -14,7 +14,8 @@ import Pagination from 'react-js-pagination';
 
 import UserContext from '../../UserContext';
 import Container from '../../components/Container';
-import { getReports, getReportAlerts, getReportsDownloadURL } from '../../fetchers/activityReports';
+import { getReports, getReportAlerts } from '../../fetchers/activityReports';
+import { getReportsDownloadURL } from '../../fetchers/helpers';
 import NewReport from './NewReport';
 import 'uswds/dist/css/uswds.css';
 import '@trussworks/react-uswds/lib/index.css';
@@ -108,7 +109,10 @@ function renderReports(reports, history, reportCheckboxes, handleReportSelect) {
     if (!legacyId) {
       const downloadMenuItem = {
         label: 'Download',
-        onClick: () => { document.location = getReportsDownloadURL([id]); },
+        onClick: () => {
+          const downloadURL = getReportsDownloadURL([id]);
+          window.location.assign(downloadURL);
+        },
       };
       menuItems.push(downloadMenuItem);
     }
@@ -314,14 +318,15 @@ function Landing() {
       if (!reports) return accumulator;
       const [key, value] = entry;
       if (value === false) return accumulator;
-      // const { legacyId = null } = reports.find((r) => r.id === key);
-      // if (legacyId) return accumulator;
       accumulator.push(key);
       return accumulator;
     };
 
     const downloadable = Object.entries(reportCheckboxes).reduce(toDownloadableReportIds, []);
-    document.location = getReportsDownloadURL(downloadable);
+    if (downloadable.length) {
+      const downloadURL = getReportsDownloadURL(downloadable);
+      window.location.assign(downloadURL);
+    }
   };
 
   const getClassNamesFor = (name) => (sortConfig.sortBy === name ? sortConfig.direction : '');
@@ -498,7 +503,7 @@ function Landing() {
                       {renderColumnHeader('Last saved', 'updatedAt')}
                       {renderColumnHeader('Status', 'status')}
                       <th scope="col">
-                        <ContextMenu label="Actions for selected activity reports" menuItems={headerMenuItems} />
+                        <ContextMenu label="Actions for selected reports" menuItems={headerMenuItems} />
                       </th>
                     </tr>
                   </thead>

--- a/frontend/src/pages/Landing/index.js
+++ b/frontend/src/pages/Landing/index.js
@@ -113,7 +113,7 @@ function renderReports(reports, history, reportCheckboxes, handleReportSelect) {
       menuItems.push(downloadMenuItem);
     }
 
-    const contextMenuLabel = `View activity report ${displayId}`;
+    const contextMenuLabel = `Actions for activity report ${displayId}`;
 
     const selectId = `report-${id}`;
     const isChecked = reportCheckboxes[id] || false;
@@ -391,6 +391,10 @@ function Landing() {
     );
   }
 
+  const headerMenuItems = [
+    { label: 'Download Selected Reports', onClick: () => handleDownloadClick() },
+  ];
+
   return (
     <>
       <Helmet>
@@ -450,11 +454,6 @@ function Landing() {
             <SimpleBar forceVisible="y" autoHide={false}>
               <Container className="landing inline-size" padding={0}>
                 <span className="smart-hub--table-nav" aria-label="Pagination for activity reports">
-                  <span>
-                    <button type="button" className="usa-button" onClick={handleDownloadClick}>
-                      Download Reports
-                    </button>
-                  </span>
                   <span
                     className="smart-hub--total-count"
                     aria-label={`Page ${activePage}, displaying rows ${renderTotal(
@@ -498,7 +497,9 @@ function Landing() {
                       {renderColumnHeader('Collaborator(s)', 'collaborators')}
                       {renderColumnHeader('Last saved', 'updatedAt')}
                       {renderColumnHeader('Status', 'status')}
-                      <th scope="col" aria-label="..." />
+                      <th scope="col">
+                        <ContextMenu label="Actions for selected activity reports" menuItems={headerMenuItems} />
+                      </th>
                     </tr>
                   </thead>
                   <tbody>

--- a/frontend/src/pages/Landing/index.js
+++ b/frontend/src/pages/Landing/index.js
@@ -487,7 +487,7 @@ function Landing() {
                   <thead>
                     <tr>
                       <th className="width-8" aria-label="Select">
-                        <Checkbox id="all-reports" label="" onChange={toggleSelectAll} checked={allReportsChecked} aria-label="Select or deselect all reports" />
+                        <Checkbox id="all-reports" label="" onChange={toggleSelectAll} checked={allReportsChecked} aria-label="Select or de-select all reports" />
                       </th>
                       {renderColumnHeader('Report ID', 'regionId')}
                       {renderColumnHeader('Grantee', 'activityRecipients')}

--- a/frontend/src/pages/Landing/index.js
+++ b/frontend/src/pages/Landing/index.js
@@ -378,7 +378,7 @@ function Landing() {
   const message = history.location.state && history.location.state.message;
   if (message) {
     msg = (
-      <div>
+      <>
         You successfully
         {' '}
         {message.status}
@@ -392,7 +392,7 @@ function Landing() {
         on
         {' '}
         {message.time}
-      </div>
+      </>
     );
   }
 
@@ -417,7 +417,7 @@ function Landing() {
                 <Button
                   role="button"
                   unstyled
-                  aria-label="dissmiss alert"
+                  aria-label="dismiss alert"
                   onClick={() => updateShowAlert(false)}
                 >
                   <span className="fa-sm">

--- a/frontend/src/pages/Landing/index.js
+++ b/frontend/src/pages/Landing/index.js
@@ -120,7 +120,7 @@ function renderReports(reports, history, reportCheckboxes, handleReportSelect) {
 
     return (
       <tr key={`landing_${id}`}>
-        <td>
+        <td className="width-8">
           <Checkbox id={selectId} label="" value={id} checked={isChecked} onChange={handleReportSelect} aria-label={`Select ${displayId}`} />
         </td>
         <th scope="row" className="smart-hub--blue">
@@ -486,7 +486,7 @@ function Landing() {
                   </caption>
                   <thead>
                     <tr>
-                      <th aria-label="Select">
+                      <th className="width-8" aria-label="Select">
                         <Checkbox id="all-reports" label="" onChange={toggleSelectAll} checked={allReportsChecked} aria-label="Select or deselect all reports" />
                       </th>
                       {renderColumnHeader('Report ID', 'regionId')}


### PR DESCRIPTION
**Description of change**

Added:
- a new column with checkboxes to the Activity Reports page. Adjusted layout a bit.
- a ContextMenu in the table header for performing actions on selected reports. Only 'Download Selected Reports' for now
- a checkbox in the table header that selects/deselects all visible reports in the list.
- a Download menu item for each (non-legacy) report and for the table overall (using the table header ContextMenu).

**How to test**

Create some non-legacy reports. Use the checkboxes to select/deselect reports, then use the table header context menu to trigger a download of selected reports. You can also use the context menu for an individual report to download a single report as a CSV.

**Issue(s)**
* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-89

**Checklist**
<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] Code tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
