### PR TITLE
Bug: Fix Can Reset report policy

### DIFF
--- a/src/policies/activityReport.js
+++ b/src/policies/activityReport.js
@@ -31,7 +31,7 @@ export default class ActivityReport {
   }
 
   canReset() {
-    return (this.isAuthor || this.isCollaborator)
+    return (this.isAuthor() || this.isCollaborator())
       && this.activityReport.status === REPORT_STATUSES.SUBMITTED;
   }
 

--- a/src/policies/activityReport.test.js
+++ b/src/policies/activityReport.test.js
@@ -146,7 +146,7 @@ describe('Activity Report policies', () => {
       const report = activityReport(author.id, collaborator, REPORT_STATUSES.SUBMITTED);
       const policy = new ActivityReport(otherUser, report);
       expect(policy.canReset()).toBeFalsy();
-    })
+    });
   });
 
   describe('canViewLegacy', () => {

--- a/src/policies/activityReport.test.js
+++ b/src/policies/activityReport.test.js
@@ -141,6 +141,12 @@ describe('Activity Report policies', () => {
       const policy = new ActivityReport(collaborator, report);
       expect(policy.canReset()).toBeTruthy();
     });
+
+    it('is false for other users', async () => {
+      const report = activityReport(author.id, collaborator, REPORT_STATUSES.SUBMITTED);
+      const policy = new ActivityReport(otherUser, report);
+      expect(policy.canReset()).toBeFalsy();
+    })
   });
 
   describe('canViewLegacy', () => {

--- a/src/policies/activityReport.test.js
+++ b/src/policies/activityReport.test.js
@@ -124,25 +124,25 @@ describe('Activity Report policies', () => {
   });
 
   describe('canReset', () => {
-    it('is false for reports that have not been submitted', async () => {
+    it('is false for reports that have not been submitted', () => {
       const report = activityReport(author.id, null, REPORT_STATUSES.APPROVED);
       const policy = new ActivityReport(author, report);
       expect(policy.canReset()).toBeFalsy();
     });
 
-    it('is true for the author', async () => {
+    it('is true for the author', () => {
       const report = activityReport(author.id, null, REPORT_STATUSES.SUBMITTED);
       const policy = new ActivityReport(author, report);
       expect(policy.canReset()).toBeTruthy();
     });
 
-    it('is true for collaborators', async () => {
+    it('is true for collaborators', () => {
       const report = activityReport(author.id, collaborator, REPORT_STATUSES.SUBMITTED);
       const policy = new ActivityReport(collaborator, report);
       expect(policy.canReset()).toBeTruthy();
     });
 
-    it('is false for other users', async () => {
+    it('is false for other users', () => {
       const report = activityReport(author.id, collaborator, REPORT_STATUSES.SUBMITTED);
       const policy = new ActivityReport(otherUser, report);
       expect(policy.canReset()).toBeFalsy();


### PR DESCRIPTION
**Description of change**
I ran across this bug while writing tests for a different ticket

**How to test**
New test written

**Issue(s)**
n/a

**Checklist**
<!-- Add details to each completed item -->
- [n/a] Meets issue criteria
- [x] Code tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
