### PR TITLE
Improve test output  readability

### DIFF
--- a/bin/run-tests
+++ b/bin/run-tests
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 declare -a options=(frontend backend)
 declare lr=">>>>>>>>"
 declare -i exit_code=0
@@ -18,6 +17,7 @@ check_exit() {
 main() {
     local opt=""
     local docker="true"
+    local verbose="false"
 
     while [[ $# -gt 0 ]]
     do
@@ -25,6 +25,10 @@ main() {
       case "$key" in
         -l|--local)
           docker="false"
+          shift
+          ;;
+        -v | --verbose)
+          verbose="true"
           shift
           ;;
         *)
@@ -73,24 +77,32 @@ main() {
 
     if [[ "$opt" == "backend" || -z "$opt" ]]; then
         # Test backend
+        command="yarn test:ci --colors"
+        if [ $verbose == "false" ]; then
+          command="yarn test:ci --silent --colors"
+        fi
         echo
         log "Running backend tests"
         if [[ $docker == "true" ]]; then
-          docker exec test-backend bash -c "yarn test:ci"
+          docker exec test-backend bash -c "$command"
         else
-          yarn test:ci
+          $command
         fi
         check_exit "$?"
     fi
 
     if [[ "$opt" == "frontend" || -z "$opt" ]]; then
         # Test frontend
+        command="yarn --cwd frontend run test:ci --colors"
+        if [ $verbose == "false" ]; then
+          command="yarn --cwd frontend run test:ci --silent --colors"
+        fi
         echo
         log "Running frontend tests"
         if [[ $docker == "true" ]]; then
-          docker exec test-frontend bash -c "yarn --cwd frontend run test:ci"
+          docker exec test-frontend bash -c "$command"
         else
-          yarn --cwd frontend run test:ci
+          $command
         fi
         check_exit "$?"
     fi


### PR DESCRIPTION
**Description of change**
The tests are not super easy to read when run on your laptop. There is a ton of output and the results aren't colorized.
This pull request makes the tests much less noisy by default and adds colors. You can still get the more verbose output by using command line flags.

**How to test**
Run the local tests as before `yarn docker:test` or `yarn docker:test --local`.
The test messages should be much quieter and the tests should be colored to show pass/fail.
Run the the command again with either the `-v` or `--verbose` flag. 
You should see the more verbose output that you are used to seeing.
