### PR TITLE
Non-grantee reports require objectives

### DIFF
--- a/frontend/src/components/Navigator/components/NavigatorHeader.js
+++ b/frontend/src/components/Navigator/components/NavigatorHeader.js
@@ -5,16 +5,18 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
-const NavigatorHeader = ({ label }) => {
+const NavigatorHeader = ({ label, titleOverride, formData }) => {
   useEffect(() => {
     document.getElementsByClassName('usa-step-indicator__heading-text')[0].focus();
   }, []);
+
+  const finalLabel = titleOverride ? titleOverride(formData) : label;
 
   return (
     <div className="usa-step-indicator__header">
       <h2 className="usa-step-indicator__heading">
         {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
-        <span tabIndex="0" className="usa-step-indicator__heading-text">{label}</span>
+        <span tabIndex="0" className="usa-step-indicator__heading-text">{finalLabel}</span>
       </h2>
     </div>
   );
@@ -22,6 +24,12 @@ const NavigatorHeader = ({ label }) => {
 
 NavigatorHeader.propTypes = {
   label: PropTypes.string.isRequired,
+  titleOverride: PropTypes.func,
+  formData: PropTypes.shape({}).isRequired,
+};
+
+NavigatorHeader.defaultProps = {
+  titleOverride: null,
 };
 
 export default NavigatorHeader;

--- a/frontend/src/components/Navigator/index.js
+++ b/frontend/src/components/Navigator/index.js
@@ -190,6 +190,8 @@ function Navigator({
                 <NavigatorHeader
                   key={page.label}
                   label={page.label}
+                  titleOverride={page.titleOverride}
+                  formData={formData}
                 />
                 {hasErrors
                 && (
@@ -262,7 +264,7 @@ Navigator.propTypes = {
   reportId: PropTypes.node.isRequired,
   reportCreator: PropTypes.shape({
     name: PropTypes.string,
-    role: PropTypes.string,
+    role: PropTypes.arrayOf(PropTypes.string),
   }),
 };
 

--- a/frontend/src/pages/ActivityReport/Pages/PrintSummary.js
+++ b/frontend/src/pages/ActivityReport/Pages/PrintSummary.js
@@ -9,7 +9,7 @@ const PrintSummary = ({ reportCreator = {} }) => {
   let creatorText = null;
 
   if (name && role) {
-    creatorText = `${name}, ${role}`;
+    creatorText = `${name}, ${role.join(', ')}`;
   } else if (name) {
     creatorText = name;
   }
@@ -35,13 +35,13 @@ const PrintSummary = ({ reportCreator = {} }) => {
 PrintSummary.propTypes = {
   reportCreator: PropTypes.shape({
     name: PropTypes.string,
-    role: PropTypes.string,
+    role: PropTypes.arrayOf(PropTypes.string),
   }),
 };
 PrintSummary.defaultProps = {
   reportCreator: {
     name: null,
-    role: null,
+    role: [],
   },
 };
 

--- a/frontend/src/pages/ActivityReport/Pages/Review/__tests__/index.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/__tests__/index.js
@@ -17,7 +17,7 @@ const approvers = [
 
 const reportCreator = {
   name: 'Walter Burns',
-  role: 'Reporter',
+  role: ['Reporter'],
 };
 
 const RenderReview = ({

--- a/frontend/src/pages/ActivityReport/Pages/Review/index.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/index.js
@@ -125,7 +125,7 @@ ReviewSubmit.propTypes = {
   }).isRequired,
   reportCreator: PropTypes.shape({
     name: PropTypes.string.isRequired,
-    role: PropTypes.string.isRequired,
+    role: PropTypes.arrayOf(PropTypes.string).isRequired,
   }).isRequired,
   // eslint-disable-next-line react/forbid-prop-types
   reviewItems: PropTypes.arrayOf(

--- a/frontend/src/pages/ActivityReport/Pages/__tests__/PrintSummary.js
+++ b/frontend/src/pages/ActivityReport/Pages/__tests__/PrintSummary.js
@@ -6,7 +6,7 @@ import PrintSummary from '../PrintSummary';
 
 describe('PrintSummary', () => {
   it('when a reportCreator with name and role is provided, it renders that', () => {
-    const reportCreator = { name: 'Lois Lane', role: 'Reporter' };
+    const reportCreator = { name: 'Lois Lane', role: ['Reporter'] };
 
     render(
       <PrintSummary reportCreator={reportCreator} />,
@@ -47,13 +47,13 @@ describe('PrintSummary', () => {
   });
 
   it('when a reportCreator has empty name and role strings, it does not render the report creator row', () => {
-    const emptyCreator = { name: '', role: '' };
+    const emptyCreator = { name: '', role: [] };
     render(
       <PrintSummary reportCreator={emptyCreator} />,
     );
     expect(screen.queryByText('Report Creator')).toBeNull();
 
-    const roleWithoutAName = { name: '', role: 'Ghost' };
+    const roleWithoutAName = { name: '', role: ['Ghost'] };
     render(
       <PrintSummary reportCreator={roleWithoutAName} />,
     );

--- a/frontend/src/pages/ActivityReport/Pages/activitySummary.js
+++ b/frontend/src/pages/ActivityReport/Pages/activitySummary.js
@@ -71,8 +71,9 @@ const ActivitySummary = ({
       // Goals and objectives (page 3) has required fields when the recipient
       // type is grantee, so we need to make sure that page is set as "not started"
       // when recipient type is changed and we need to clear out any previously
-      // selected goals
+      // selected goals and objectives
       setValue('goals', []);
+      setValue('objectivesWithoutGoals', []);
       setValue('pageState', { ...pageState, 3: NOT_STARTED });
     }
     previousActivityRecipientType.current = activityRecipientType;

--- a/frontend/src/pages/ActivityReport/Pages/components/Goal.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/Goal.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button } from '@trussworks/react-uswds';
+import { useFormContext } from 'react-hook-form/dist/index.ie11';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
@@ -15,6 +16,9 @@ const Goals = ({
     const newObjectives = objectives.filter((o, objectiveIndex) => index !== objectiveIndex);
     onUpdateObjectives(newObjectives);
   };
+
+  const { errors } = useFormContext();
+  const isValid = !errors.goals;
 
   const onUpdateObjective = (index, newObjective) => {
     const newObjectives = [...objectives];
@@ -42,8 +46,9 @@ const Goals = ({
           {objectives.map((objective, objectiveIndex) => (
             <div className="margin-top-1" key={objective.id}>
               <Objective
-                goalIndex={goalIndex}
-                objectiveIndex={objectiveIndex}
+                isValid={isValid}
+                parentLabel="goals"
+                objectiveAriaLabel={`${objectiveIndex + 1} on goal ${goalIndex + 1}`}
                 objective={objective}
                 onRemove={() => { if (!singleObjective) { onRemoveObjective(objectiveIndex); } }}
                 onUpdate={(newObjective) => onUpdateObjective(objectiveIndex, newObjective)}

--- a/frontend/src/pages/ActivityReport/Pages/components/Goal.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/Goal.js
@@ -17,9 +17,6 @@ const Goals = ({
     onUpdateObjectives(newObjectives);
   };
 
-  const { errors } = useFormContext();
-  const isValid = !errors.goals;
-
   const onUpdateObjective = (index, newObjective) => {
     const newObjectives = [...objectives];
     newObjectives[index] = newObjective;
@@ -46,7 +43,6 @@ const Goals = ({
           {objectives.map((objective, objectiveIndex) => (
             <div className="margin-top-1" key={objective.id}>
               <Objective
-                isValid={isValid}
                 parentLabel="goals"
                 objectiveAriaLabel={`${objectiveIndex + 1} on goal ${goalIndex + 1}`}
                 objective={objective}

--- a/frontend/src/pages/ActivityReport/Pages/components/Goal.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/Goal.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button } from '@trussworks/react-uswds';
-import { useFormContext } from 'react-hook-form/dist/index.ie11';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';

--- a/frontend/src/pages/ActivityReport/Pages/components/GranteeReviewSection.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/GranteeReviewSection.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { useFormContext } from 'react-hook-form/dist/index.ie11';
+import { isUndefined } from 'lodash';
+
+import Section from '../Review/ReviewSection';
+
+const GranteeReviewSection = () => {
+  const { watch } = useFormContext();
+  const {
+    goals,
+  } = watch();
+  return (
+    <Section
+      hidePrint={isUndefined(goals)}
+      key="Goals"
+      basePath="goals-objectives"
+      anchor="goals-and-objectives"
+      title="Goals"
+    >
+      {goals.map((goal) => {
+        const objectives = goal.objectives || [];
+        return (
+          <div key={goal.id}>
+            <div className="grid-row margin-bottom-3 desktop:margin-bottom-0 margin-top-2">
+              <span>
+                <span className="text-bold">Goal:</span>
+                {' '}
+                {goal.name}
+              </span>
+              <div className="padding-left-2 margin-top-2">
+                <>
+                  {objectives.map((objective) => (
+                    <div key={objective.id} className="desktop:flex-align-end display-flex flex-column flex-justify-center margin-top-1">
+                      <div>
+                        <span className="text-bold">Objective:</span>
+                        {' '}
+                        {objective.title}
+                      </div>
+                      <div>
+                        <span className="text-bold">TTA Provided:</span>
+                        {' '}
+                        {objective.ttaProvided}
+                      </div>
+                      <div>
+                        <span className="text-bold">Status:</span>
+                        {' '}
+                        {objective.status}
+                      </div>
+                    </div>
+                  ))}
+                </>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </Section>
+  );
+};
+
+export default GranteeReviewSection;

--- a/frontend/src/pages/ActivityReport/Pages/components/NonGranteeReviewSection.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/NonGranteeReviewSection.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { useFormContext } from 'react-hook-form/dist/index.ie11';
+import { isUndefined } from 'lodash';
+
+import Section from '../Review/ReviewSection';
+
+const NonGranteeReviewSection = () => {
+  const { watch } = useFormContext();
+  const {
+    objectivesWithoutGoals,
+  } = watch();
+  return (
+    <Section
+      hidePrint={isUndefined(objectivesWithoutGoals)}
+      key="Objectives"
+      basePath="goals-objectives"
+      anchor="goals-and-objectives"
+      title="Objectives"
+    >
+      <>
+        {objectivesWithoutGoals.map((objective) => (
+          <div key={objective.id} className="desktop:flex-align-end display-flex flex-column flex-justify-center margin-top-1">
+            <div>
+              <span className="text-bold">Objective:</span>
+              {' '}
+              {objective.title}
+            </div>
+            <div>
+              <span className="text-bold">TTA Provided:</span>
+              {' '}
+              {objective.ttaProvided}
+            </div>
+            <div>
+              <span className="text-bold">Status:</span>
+              {' '}
+              {objective.status}
+            </div>
+          </div>
+        ))}
+      </>
+    </Section>
+  );
+};
+
+export default NonGranteeReviewSection;

--- a/frontend/src/pages/ActivityReport/Pages/components/Objective.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/Objective.js
@@ -16,12 +16,15 @@ const statuses = [
 ];
 
 const Objective = ({
-  goalIndex, objectiveIndex, objective, onRemove, onUpdate,
+  objectiveAriaLabel,
+  objective,
+  onRemove,
+  onUpdate,
+  parentLabel,
 }) => {
-  const objectiveAriaLabel = `${objectiveIndex + 1} on goal ${goalIndex + 1}`;
   const firstInput = useRef();
   const { errors, trigger } = useFormContext();
-  const isValid = !errors.goals;
+  const isValid = !errors[parentLabel];
 
   useEffect(() => {
     if (firstInput.current) {
@@ -48,11 +51,11 @@ const Objective = ({
       updateShowEdit(false);
       onUpdate(editableObject);
     } else {
-      trigger('goals');
+      trigger(parentLabel);
     }
 
     if (!isValid) {
-      trigger('goals');
+      trigger(parentLabel);
     }
   };
 
@@ -171,10 +174,14 @@ Objective.propTypes = {
     ttaProvided: PropTypes.string,
     status: PropTypes.string,
   }).isRequired,
-  objectiveIndex: PropTypes.number.isRequired,
-  goalIndex: PropTypes.number.isRequired,
   onRemove: PropTypes.func.isRequired,
   onUpdate: PropTypes.func.isRequired,
+  parentLabel: PropTypes.string.isRequired,
+  objectiveAriaLabel: PropTypes.string,
+};
+
+Objective.defaultProps = {
+  objectiveAriaLabel: '',
 };
 
 export default Objective;

--- a/frontend/src/pages/ActivityReport/Pages/components/ObjectivePicker.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/ObjectivePicker.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import { useFormContext } from 'react-hook-form/dist/index.ie11';
+import { v4 as uuidv4 } from 'uuid';
+import { Button } from '@trussworks/react-uswds';
+
+import FormItem from '../../../../components/FormItem';
+import Objective from './Objective';
+import { validateObjectives } from './objectiveValidator';
+
+const OBJECTIVE_LABEL = 'objectivesWithoutGoals';
+
+const createObjective = () => ({
+  title: '', ttaProvided: '', status: 'Not Started', id: uuidv4(), new: true,
+});
+
+const ObjectivePicker = () => {
+  const {
+    watch, setValue, register,
+  } = useFormContext();
+  const objectives = watch(OBJECTIVE_LABEL);
+
+  register(OBJECTIVE_LABEL, {
+    validate: (e) => validateObjectives(e),
+  });
+
+  const onRemoveObjective = (index) => {
+    const newObjectives = objectives.filter((o, objectiveIndex) => index !== objectiveIndex);
+    setValue(OBJECTIVE_LABEL, newObjectives);
+  };
+
+  const onUpdateObjective = (index, newObjective) => {
+    const newObjectives = [...objectives];
+    newObjectives[index] = newObjective;
+    setValue(OBJECTIVE_LABEL, newObjectives);
+  };
+
+  const singleObjective = objectives.length <= 1;
+
+  return (
+    <div className="margin-top-4">
+      <FormItem
+        label='Because goals are associated with grantees, there is no "goal" field in this section. You must create at least one objective for this activity.'
+        name={OBJECTIVE_LABEL}
+        fieldSetWrapper
+      >
+        {objectives.map((objective, objectiveIndex) => (
+          <div className="margin-top-1" key={objective.id}>
+            <Objective
+              parentLabel={OBJECTIVE_LABEL}
+              objectiveAriaLabel={objectiveIndex + 1}
+              objective={objective}
+              onRemove={() => { if (!singleObjective) { onRemoveObjective(objectiveIndex); } }}
+              onUpdate={(newObjective) => onUpdateObjective(objectiveIndex, newObjective)}
+            />
+          </div>
+        ))}
+      </FormItem>
+      <Button
+        type="button"
+        onClick={() => {
+          setValue(OBJECTIVE_LABEL, [...objectives, createObjective()]);
+        }}
+        outline
+        aria-label="add objective"
+      >
+        Add New Objective
+      </Button>
+    </div>
+  );
+};
+
+export default ObjectivePicker;

--- a/frontend/src/pages/ActivityReport/Pages/components/__tests__/Objective.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/__tests__/Objective.js
@@ -22,6 +22,8 @@ const RenderObjective = ({
         objective={objective}
         onRemove={onRemove}
         onUpdate={onUpdate}
+        parentLabel="goals"
+        objectiveAriaLabel="1 on goal 1"
         goalIndex={0}
         objectiveIndex={0}
       />

--- a/frontend/src/pages/ActivityReport/Pages/components/__tests__/ObjectivePicker.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/__tests__/ObjectivePicker.js
@@ -1,0 +1,79 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { FormProvider, useForm } from 'react-hook-form/dist/index.ie11';
+
+import ObjectivePicker from '../ObjectivePicker';
+import { withText } from '../../../../../testHelpers';
+
+// eslint-disable-next-line react/prop-types
+const RenderObjective = ({ objectivesWithoutGoals }) => {
+  const hookForm = useForm({
+    mode: 'onChange',
+    defaultValues: {
+      objectivesWithoutGoals,
+    },
+  });
+
+  return (
+    <FormProvider {...hookForm}>
+      <ObjectivePicker />
+    </FormProvider>
+  );
+};
+
+const objectives = [
+  {
+    id: 1, title: 'title', ttaProvided: 'tta', status: 'In Progress',
+  },
+  {
+    id: 2, title: 'title two', ttaProvided: 'tta two', status: 'In Progress',
+  },
+];
+
+describe('ObjectivePicker', () => {
+  it('renders created objectives', async () => {
+    render(<RenderObjective objectivesWithoutGoals={objectives} />);
+
+    const title = await screen.findByText('title');
+    expect(title).toBeVisible();
+  });
+
+  it('can remove objectives', async () => {
+    render(<RenderObjective objectivesWithoutGoals={objectives} />);
+
+    const button = await screen.findByRole('button', { name: 'Edit or delete objective 1' });
+    userEvent.click(button);
+    const destroy = await screen.findByRole('button', { name: 'Delete' });
+    userEvent.click(destroy);
+    const title = await screen.findByText('title two');
+    expect(title).toBeVisible();
+    const buttons = await screen.findAllByText(withText('TTA Provided: '));
+    expect(buttons.length).toBe(1);
+  });
+
+  it('can update objectives', async () => {
+    render(<RenderObjective objectivesWithoutGoals={objectives} />);
+
+    const button = await screen.findByRole('button', { name: 'Edit or delete objective 1' });
+    userEvent.click(button);
+    const edit = await screen.findByRole('button', { name: 'Edit' });
+    userEvent.click(edit);
+    const titleEditbox = await screen.findByRole('textbox', { name: 'title for objective 1' });
+    userEvent.type(titleEditbox, 'test');
+    const save = await screen.findByRole('button', { name: 'Save objective 1' });
+    userEvent.click(save);
+    const title = await screen.findByText(withText('Objective: titletest'));
+    expect(title).toBeVisible();
+  });
+
+  it('can add additional objectives', async () => {
+    render(<RenderObjective objectivesWithoutGoals={objectives} />);
+    const button = await screen.findByRole('button', { name: 'add objective' });
+    userEvent.click(button);
+    const title = await screen.findByRole('textbox', { name: 'title for objective 3' });
+    expect(title).toBeVisible();
+  });
+});

--- a/frontend/src/pages/ActivityReport/Pages/components/__tests__/objectiveValidator.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/__tests__/objectiveValidator.js
@@ -1,0 +1,33 @@
+import {
+  validateObjectives,
+  OBJECTIVES_EMPTY,
+} from '../objectiveValidator';
+
+import { UNFINISHED_OBJECTIVES } from '../goalValidator';
+
+const missingTitle = {
+  title: '',
+  ttaProvided: 'ttaProvided',
+};
+
+const validObjective = {
+  title: 'title',
+  ttaProvided: 'ttaProvided',
+};
+
+describe('validateObjectives', () => {
+  it('returns invalid if empty', () => {
+    const res = validateObjectives([]);
+    expect(res).toEqual(OBJECTIVES_EMPTY);
+  });
+
+  it('returns invalid for incomplete objectives', () => {
+    const res = validateObjectives([missingTitle]);
+    expect(res).toEqual(UNFINISHED_OBJECTIVES);
+  });
+
+  it('returns true for valid objectives', () => {
+    const res = validateObjectives([validObjective]);
+    expect(res).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/ActivityReport/Pages/components/goalValidator.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/goalValidator.js
@@ -31,5 +31,9 @@ export const validateGoals = (goals) => {
     return GOALS_EMPTY;
   }
 
-  return unfinishedGoals(goals) || true;
+  const unfinishedMessage = unfinishedGoals(goals);
+  if (unfinishedMessage) {
+    return unfinishedMessage;
+  }
+  return true;
 };

--- a/frontend/src/pages/ActivityReport/Pages/components/objectiveValidator.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/objectiveValidator.js
@@ -1,0 +1,11 @@
+import { unfinishedObjectives } from './goalValidator';
+
+export const OBJECTIVES_EMPTY = 'Every report must have at least one objective';
+
+export const validateObjectives = (objectives) => {
+  if (objectives.length < 1) {
+    return OBJECTIVES_EMPTY;
+  }
+
+  return unfinishedObjectives(objectives) || true;
+};

--- a/frontend/src/pages/ActivityReport/Pages/components/objectiveValidator.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/objectiveValidator.js
@@ -7,5 +7,10 @@ export const validateObjectives = (objectives) => {
     return OBJECTIVES_EMPTY;
   }
 
-  return unfinishedObjectives(objectives) || true;
+  const unfinishedMessage = unfinishedObjectives(objectives);
+
+  if (unfinishedMessage) {
+    return unfinishedMessage;
+  }
+  return true;
 };

--- a/frontend/src/pages/ActivityReport/Pages/goalsObjectives.js
+++ b/frontend/src/pages/ActivityReport/Pages/goalsObjectives.js
@@ -12,6 +12,10 @@ import Section from './Review/ReviewSection';
 import GoalPicker from './components/GoalPicker';
 import { getGoals } from '../../../fetchers/activityReports';
 import { validateGoals } from './components/goalValidator';
+import ObjectivePicker from './components/ObjectivePicker';
+import GranteeReviewSection from './components/GranteeReviewSection';
+import NonGranteeReviewSection from './components/NonGranteeReviewSection';
+import { validateObjectives } from './components/objectiveValidator';
 
 const GoalsObjectives = () => {
   const {
@@ -42,6 +46,11 @@ const GoalsObjectives = () => {
       <Helmet>
         <title>Goals and objectives</title>
       </Helmet>
+      {!recipientGrantee && (
+        <Fieldset className="smart-hub--report-legend margin-top-4" legend="Objectives for non-grantee TTA">
+          <ObjectivePicker />
+        </Fieldset>
+      )}
       {showGoals
         && (
         <Fieldset className="smart-hub--report-legend margin-top-4" legend="Goals and objectives">
@@ -69,8 +78,10 @@ const ReviewSection = () => {
   const { watch } = useFormContext();
   const {
     context,
-    goals,
+    activityRecipientType,
   } = watch();
+
+  const nonGrantee = activityRecipientType === 'non-grantee';
 
   return (
     <>
@@ -86,51 +97,10 @@ const ReviewSection = () => {
           name="context"
         />
       </Section>
-      <Section
-        hidePrint={isUndefined(goals)}
-        key="Goals"
-        basePath="goals-objectives"
-        anchor="goals-and-objectives"
-        title="Goals"
-      >
-        {goals.map((goal) => {
-          const objectives = goal.objectives || [];
-          return (
-            <div key={goal.id}>
-              <div className="grid-row margin-bottom-3 desktop:margin-bottom-0 margin-top-2">
-                <span>
-                  <span className="text-bold">Goal:</span>
-                  {' '}
-                  {goal.name}
-                </span>
-                <div className="padding-left-2 margin-top-2">
-                  <>
-                    {objectives.map((objective) => (
-                      <div key={objective.id} className="desktop:flex-align-end display-flex flex-column flex-justify-center margin-top-1">
-                        <div>
-                          <span className="text-bold">Objective:</span>
-                          {' '}
-                          {objective.title}
-                        </div>
-                        <div>
-                          <span className="text-bold">TTA Provided:</span>
-                          {' '}
-                          {objective.ttaProvided}
-                        </div>
-                        <div>
-                          <span className="text-bold">Status:</span>
-                          {' '}
-                          {objective.status}
-                        </div>
-                      </div>
-                    ))}
-                  </>
-                </div>
-              </div>
-            </div>
-          );
-        })}
-      </Section>
+      {!nonGrantee
+        && <GranteeReviewSection />}
+      {nonGrantee
+        && <NonGranteeReviewSection />}
     </>
   );
 };
@@ -138,9 +108,27 @@ const ReviewSection = () => {
 export default {
   position: 3,
   label: 'Goals and objectives',
+  titleOverride: (formData) => {
+    const { activityRecipientType } = formData;
+    if (activityRecipientType === 'non-grantee') {
+      return 'Objectives';
+    }
+    return 'Goals and objectives';
+  },
   path: 'goals-objectives',
   review: false,
-  isPageComplete: (formData) => formData.activityRecipientType !== 'grantee' || validateGoals(formData.goals) === true,
+  isPageComplete: (formData) => {
+    const { activityRecipientType } = formData;
+
+    if (!activityRecipientType) {
+      return false;
+    }
+
+    if (activityRecipientType === 'non-grantee') {
+      return validateObjectives(formData.objectivesWithoutGoals) === true;
+    }
+    return activityRecipientType !== 'grantee' || validateGoals(formData.goals) === true;
+  },
   reviewSection: () => <ReviewSection />,
   render: () => (
     <GoalsObjectives />

--- a/frontend/src/pages/ActivityReport/index.js
+++ b/frontend/src/pages/ActivityReport/index.js
@@ -49,6 +49,7 @@ const defaultValues = {
   grantees: [],
   nonECLKCResourcesUsed: [{ value: '' }],
   numberOfParticipants: null,
+  objectivesWithoutGoals: [],
   otherResources: [],
   participantCategory: '',
   participants: [],
@@ -292,7 +293,7 @@ ActivityReport.propTypes = {
   user: PropTypes.shape({
     id: PropTypes.number,
     name: PropTypes.string,
-    role: PropTypes.string,
+    role: PropTypes.arrayOf(PropTypes.string),
   }).isRequired,
 };
 

--- a/src/migrations/20210419174123-remove-not-null-on-objectives-goal.js
+++ b/src/migrations/20210419174123-remove-not-null-on-objectives-goal.js
@@ -1,0 +1,16 @@
+/* eslint-disable no-multi-str */
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.changeColumn('"Objectives"', 'goalId', {
+      type: Sequelize.INTEGER,
+      allowNull: true,
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.changeColumn('"Objectives"', 'goalId', {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+    });
+  },
+};

--- a/src/models/activityReport.js
+++ b/src/models/activityReport.js
@@ -32,10 +32,22 @@ export default (sequelize, DataTypes) => {
       ActivityReport.hasMany(models.NextStep, { foreignKey: 'activityReportId', as: 'specialistNextSteps' });
       ActivityReport.hasMany(models.NextStep, { foreignKey: 'activityReportId', as: 'granteeNextSteps' });
       ActivityReport.belongsToMany(models.Objective, {
+        scope: {
+          goalId: { [Op.is]: null },
+        },
         through: models.ActivityReportObjective,
         foreignKey: 'activityReportId',
         otherKey: 'objectiveId',
-        as: 'objectives',
+        as: 'objectivesWithoutGoals',
+      });
+      ActivityReport.belongsToMany(models.Objective, {
+        scope: {
+          goalId: { [Op.not]: null },
+        },
+        through: models.ActivityReportObjective,
+        foreignKey: 'activityReportId',
+        otherKey: 'objectiveId',
+        as: 'objectivesWithGoals',
       });
     }
   }
@@ -172,7 +184,7 @@ export default (sequelize, DataTypes) => {
     goals: {
       type: DataTypes.VIRTUAL,
       get() {
-        const objectives = this.objectives || [];
+        const objectives = this.objectivesWithGoals || [];
         const goalsArray = objectives.map((o) => o.goal);
         const goals = uniqWith(goalsArray, isEqual);
 

--- a/src/models/objective.js
+++ b/src/models/objective.js
@@ -16,7 +16,10 @@ module.exports = (sequelize, DataTypes) => {
     }
   }
   Objective.init({
-    goalId: DataTypes.INTEGER,
+    goalId: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
     title: DataTypes.TEXT,
     ttaProvided: DataTypes.TEXT,
     status: DataTypes.STRING,

--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -560,9 +560,9 @@ export async function createOrUpdate(newActivityReport, report) {
       await saveNotes(id, specialistNextSteps, false, transaction);
     }
 
-    if (objectivesWithoutGoals) {
+    if (allFields.activityRecipientType === 'non-grantee' && objectivesWithoutGoals) {
       await saveObjectivesForReport(objectivesWithoutGoals, savedReport, transaction);
-    } else if (goals) {
+    } else if (allFields.activityRecipientType === 'grantee' && goals) {
       await saveGoalsForReport(goals, savedReport, transaction);
     }
   });

--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -23,6 +23,8 @@ import {
   saveGoalsForReport, copyGoalsToGrants,
 } from './goals';
 
+import { saveObjectivesForReport } from './objectives';
+
 async function saveReportCollaborators(activityReportId, collaborators, transaction) {
   const newCollaborators = collaborators.map((collaborator) => ({
     activityReportId,
@@ -226,11 +228,15 @@ export function activityReportById(activityReportId) {
       },
       {
         model: Objective,
-        as: 'objectives',
+        as: 'objectivesWithGoals',
         include: [{
           model: Goal,
           as: 'goal',
         }],
+      },
+      {
+        model: Objective,
+        as: 'objectivesWithoutGoals',
       },
       {
         model: User,
@@ -496,7 +502,8 @@ export async function createOrUpdate(newActivityReport, report) {
   let savedReport;
   const {
     goals,
-    objectives,
+    objectivesWithGoals,
+    objectivesWithoutGoals,
     collaborators,
     activityRecipients,
     attachments,
@@ -553,7 +560,9 @@ export async function createOrUpdate(newActivityReport, report) {
       await saveNotes(id, specialistNextSteps, false, transaction);
     }
 
-    if (goals) {
+    if (objectivesWithoutGoals) {
+      await saveObjectivesForReport(objectivesWithoutGoals, savedReport, transaction);
+    } else if (goals) {
       await saveGoalsForReport(goals, savedReport, transaction);
     }
   });
@@ -646,18 +655,6 @@ export async function getDownloadableActivityReports(readRegions, {
               required: false,
             },
           ],
-        },
-        {
-          model: Objective,
-          as: 'objectives',
-          include: [{
-            model: Goal,
-            as: 'goal',
-            include: [{
-              model: Objective,
-              as: 'objectives',
-            }],
-          }],
         },
         {
           model: File,

--- a/src/services/objectives.js
+++ b/src/services/objectives.js
@@ -1,0 +1,39 @@
+/* eslint-disable import/prefer-default-export */
+import {
+  Objective,
+  ActivityReportObjective,
+} from '../models';
+
+export async function saveObjectivesForReport(objectives, report, transaction) {
+  const reportObjectives = await ActivityReportObjective.findAll({
+    where: {
+      activityReportId: report.id,
+    },
+  });
+
+  const objectiveIds = reportObjectives.map((reportObjective) => reportObjective.objectiveId);
+  await ActivityReportObjective.destroy({
+    where: {
+      activityReportId: report.id,
+    },
+  },
+  { transaction });
+
+  await Objective.destroy({
+    where: {
+      id: objectiveIds,
+    },
+  },
+  { transaction });
+
+  await Promise.all(objectives.map(async (objective) => {
+    const { id, ...objectiveForDb } = objective;
+    const createdObjective = await Objective.create(objectiveForDb, { transaction });
+
+    await ActivityReportObjective.create({
+      objectiveId: createdObjective.id,
+      activityReportId: report.id,
+    },
+    { transaction });
+  }));
+}

--- a/src/services/objectives.test.js
+++ b/src/services/objectives.test.js
@@ -1,0 +1,100 @@
+import db, {
+  ActivityReport, User, Objective, ActivityReportObjective, sequelize,
+} from '../models';
+import { REPORT_STATUSES } from '../constants';
+
+import { saveObjectivesForReport } from './objectives';
+
+const mockUser = {
+  id: 2000,
+  homeRegionId: 1,
+  name: 'user2000',
+  hsesUsername: 'user2000',
+  hsesUserId: '2000',
+};
+
+const reportObject = {
+  status: REPORT_STATUSES.DRAFT,
+  userId: mockUser.id,
+  regionId: 1,
+  lastUpdatedById: mockUser.id,
+};
+
+describe('Objectives DB service', () => {
+  let report;
+  let objective;
+  const objectives = [
+    {
+      id: 'uuid',
+      title: 'first objective',
+      ttaProvided: 'tta first',
+      status: 'In Progress',
+    },
+    {
+      id: 'uuid2',
+      title: 'second objective',
+      ttaProvided: 'tta second',
+      status: 'In Progress',
+    },
+  ];
+
+  beforeAll(async () => {
+    await User.create(mockUser);
+    report = await ActivityReport.create(reportObject);
+    objective = await Objective.create({
+      title: 'title',
+      ttaProvided: 'tta provided',
+      status: 'status',
+    });
+
+    await ActivityReportObjective.create({
+      objectiveId: objective.id,
+      activityReportId: report.id,
+    });
+
+    await sequelize.transaction(async (transaction) => {
+      await saveObjectivesForReport(objectives, report, transaction);
+    });
+  });
+
+  afterAll(async () => {
+    const aros = await ActivityReportObjective.findAll({ where: { activityReportId: report.id } });
+    const objectiveIds = aros.map((aro) => aro.objectiveId);
+    await ActivityReportObjective.destroy({ where: { activityReportId: report.id } });
+    await Objective.destroy({ where: { id: objectiveIds } });
+    await ActivityReport.destroy({ where: { id: report.id } });
+    await User.destroy({ where: { id: mockUser.id } });
+    await db.sequelize.close();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('saveObjectivesForReport', () => {
+    it('deletes old objectives', async () => {
+      const found = await Objective.findOne({ where: { id: objective.id } });
+      expect(found).toBeNull();
+    });
+
+    it('deletes old activity report objectives', async () => {
+      const found = await ActivityReportObjective.findOne({ where: { id: objective.id } });
+      expect(found).toBeNull();
+    });
+
+    it('creates new objectives and activityReportObjectives', async () => {
+      const foundReport = await ActivityReport.findOne({
+        where: {
+          id: report.id,
+        },
+        include: [{
+          model: Objective,
+          as: 'objectivesWithoutGoals',
+        }],
+      });
+      const objs = foundReport.objectivesWithoutGoals;
+      expect(objs.length).toBe(2);
+      expect(objs.map((o) => o.title)).toEqual(objectives.map((o) => o.title));
+    });
+  });
+});


### PR DESCRIPTION
## Description of change

Added the `objectivePicker`, used by non-grantee reports. Also updated the review component to handle non-grantee reports. Made some updates to the title of the page depending on the type of report (grantee vs non-grantee).

## How to test

1) Pull down, run migrations
2) Start a new report, select `non-grantee`
3) Go to the `objectives` page. Fill out objectives, make sure the status of the page correctly updates
4) Switch to a `grantee` report, select at least one grant
5) Fill out more `objectives`. Switch back and forth between grantee and non-grantee reports and make sure the page state clears correctly

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-88


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [x] API Documentation updated
- [x] Boundary diagram updated
- [x] Logical Data Model updated
- [x] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
