### PR TITLE
APPROVE_REPORTS gives read access to approved reports

### DIFF
--- a/src/policies/activityReport.js
+++ b/src/policies/activityReport.js
@@ -71,6 +71,7 @@ export default class ActivityReport {
     const permissions = _.find(this.user.permissions,
       (permission) => (
         (permission.scopeId === SCOPES.READ_REPORTS
+        || permission.scopeId === SCOPES.APPROVE_REPORTS
         || permission.scopeId === SCOPES.READ_WRITE_REPORTS)
         && permission.regionId === this.activityReport.regionId));
     return !_.isUndefined(permissions);

--- a/src/policies/activityReport.test.js
+++ b/src/policies/activityReport.test.js
@@ -23,7 +23,7 @@ function activityReport(
   return report;
 }
 
-function user(write, read, admin, id = 1) {
+function user(write, read, admin, id = 1, approve = false) {
   const u = { id, permissions: [] };
   if (write) {
     u.permissions.push({
@@ -46,6 +46,13 @@ function user(write, read, admin, id = 1) {
     });
   }
 
+  if (approve) {
+    u.permissions.push({
+      scopeId: SCOPES.APPROVE_REPORTS,
+      regionId: 1,
+    });
+  }
+
   return u;
 }
 
@@ -55,6 +62,7 @@ const manager = user(true, false, false, 3);
 const otherUser = user(false, true, false, 4);
 const canNotReadRegion = user(false, false, false, 5);
 const admin = user(true, true, true, 6);
+const approver = user(false, false, false, 1, true);
 
 describe('Activity Report policies', () => {
   describe('canReview', () => {
@@ -164,6 +172,12 @@ describe('Activity Report policies', () => {
       expect(policy.canViewLegacy()).toBeTruthy();
     });
 
+    it('is true if the user can approver reports in the region', () => {
+      const report = activityReport(author.id);
+      const policy = new ActivityReport(approver, report);
+      expect(policy.canViewLegacy()).toBeTruthy();
+    });
+
     it('is false if the user can not view the region', () => {
       const report = activityReport(author.id);
       const policy = new ActivityReport(canNotReadRegion, report);
@@ -202,6 +216,12 @@ describe('Activity Report policies', () => {
       it('is true for users with read permissions in the region', () => {
         const report = activityReport(author.id, null, REPORT_STATUSES.APPROVED);
         const policy = new ActivityReport(otherUser, report);
+        expect(policy.canGet()).toBeTruthy();
+      });
+
+      it('is true for users with approve permissions in the region', () => {
+        const report = activityReport(author.id, null, REPORT_STATUSES.APPROVED);
+        const policy = new ActivityReport(approver, report);
         expect(policy.canGet()).toBeTruthy();
       });
     });


### PR DESCRIPTION
## Description of change

APPROVE_REPORTS now grants read access on reports that have been approved. Before a user had to have both APPROVE_REPORTS and one of READ_REPORTS or READ_WRITE_REPORTS in a region to view approved reports.

## How to test

1) Have at least one approved report
2) Give a user only APPROVE REPORTS permission on the region the report is in (default would be region 1). Make sure this user is not the one used to approve the report from step 2
3) Try to open the report in step 2 with the user from step 3. You should see an error
4) Checkout this branch, reload the report in step 2 with the user from step 3. You should be able to load the report

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-59

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- ~[ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)~
- ~[ ] API Documentation updated~
- ~[ ] Boundary diagram updated~
- ~[ ] Logical Data Model updated~
- ~[ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
