### PR TITLE
Adjust text on Activity Report delete confirmation modal

### DIFF
--- a/frontend/src/components/DeleteReportModal.js
+++ b/frontend/src/components/DeleteReportModal.js
@@ -47,7 +47,11 @@ const DeleteModal = ({
         )}
       >
         Are you sure you want to delete this activity report?
-        This action can only be undone by a TTA Smart Hub Administrator
+        This action
+        {' '}
+        <b>cannot</b>
+        {' '}
+        be undone.
       </Modal>
     </div>
   );


### PR DESCRIPTION
## Description of change
Based on a review, the activity report delete confirmation dialog text was adjusted to stress an inability to undo.


## How to test
Pull changes.
Attempt to delete a report.
Note that the message specified action can't be undone and  "cannot" is displayed in bold.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-83


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
