### PR TITLE
Add matches polyfill

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -149,7 +149,8 @@
     "coveragePathIgnorePatterns": [
       "<rootDir>/src/index.js",
       "<rootDir>/src/setupProxy.js",
-      "<rootDir>/src/pages/NotFound/index.js"
+      "<rootDir>/src/pages/NotFound/index.js",
+      "<rootDir>/src/polyfills.js"
     ],
     "coverageThreshold": {
       "global": {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -28,6 +28,8 @@ import RequestPermissions from './components/RequestPermissions';
 import AriaLiveContext from './AriaLiveContext';
 import AriaLiveRegion from './components/AriaLiveRegion';
 
+import './polyfills';
+
 function App() {
   const [user, updateUser] = useState();
   const [authError, updateAuthError] = useState();

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -28,8 +28,6 @@ import RequestPermissions from './components/RequestPermissions';
 import AriaLiveContext from './AriaLiveContext';
 import AriaLiveRegion from './components/AriaLiveRegion';
 
-import './polyfills';
-
 function App() {
   const [user, updateUser] = useState();
   const [authError, updateAuthError] = useState();

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,5 +1,6 @@
 import 'react-app-polyfill/ie11';
 import 'react-app-polyfill/stable';
+import './polyfills';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';

--- a/frontend/src/pages/Landing/Filter.js
+++ b/frontend/src/pages/Landing/Filter.js
@@ -76,7 +76,10 @@ function Filter({ applyFilters, forMyAlerts }) {
     // https://reactjs.org/docs/events.html#detecting-focus-entering-and-leaving
     // e.relatedTarget can be null when focus changes within the menu (when using VoiceOver)
 
-    // const isCalendarControl = e.target.classList.contains('CalendarDay') || e.target.classList.contains('DayPickerNavigation_button');
+    /**
+     * We check for these because if we don't, the filter menu will abruptly close when the calendar day
+     * or the month navigation buttons are clicked, rendering the date picker un-usable
+     */
     const isCalendarControl = e.target.matches('.CalendarDay, .DayPickerNavigation_button');
 
     if (!isCalendarControl && !e.currentTarget.contains(e.relatedTarget)) {

--- a/frontend/src/pages/Landing/Filter.js
+++ b/frontend/src/pages/Landing/Filter.js
@@ -76,6 +76,7 @@ function Filter({ applyFilters, forMyAlerts }) {
     // https://reactjs.org/docs/events.html#detecting-focus-entering-and-leaving
     // e.relatedTarget can be null when focus changes within the menu (when using VoiceOver)
 
+    // const isCalendarControl = e.target.classList.contains('CalendarDay') || e.target.classList.contains('DayPickerNavigation_button');
     const isCalendarControl = e.target.matches('.CalendarDay, .DayPickerNavigation_button');
 
     if (!isCalendarControl && !e.currentTarget.contains(e.relatedTarget)) {

--- a/frontend/src/polyfills.js
+++ b/frontend/src/polyfills.js
@@ -1,0 +1,4 @@
+if (!Element.prototype.matches) {
+  Element.prototype.matches = Element.prototype.msMatchesSelector
+                                || Element.prototype.webkitMatchesSelector;
+}


### PR DESCRIPTION
## Description of change
Previous focus/blur solution did not account for the lack of Element.matches in IE11. Polyfill is not provided by existing babel config. 

Created a polyfills.js file at the root of the project and added a Element.matches polyfill utilizing the IE11 vendor prefixed version

## How to test
Add a start date filter in IE11 and confirm that the calendar behaves appropriately

## Issue(s)
- https://ocio-jira.acf.hhs.gov/browse/TTAHUB-110
- https://ocio-jira.acf.hhs.gov/browse/TTAHUB-146

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [ ] ~JIRA ticket status updated~ **no jira access**
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)

**Not applicable (API/data model/architecture not changed)**
- [ ] ~API Documentation updated~
- [ ] ~Boundary diagram updated~
- [ ] ~Logical Data Model updated~
- [ ] ~[Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
