### PR TITLE
Add support for PIV card logins and disable debug logging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,7 @@ parameters:
     default: "main"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
-    default: "add-wysisyg-editor"
+    default: "kw-fix-piv-card-login"
     type: string
   prod_new_relic_app_id:
     default: "877570491"

--- a/deployment_config/dev_vars.yml
+++ b/deployment_config/dev_vars.yml
@@ -4,7 +4,7 @@ web_memory: 512M
 worker_instances: 1
 worker_memory: 512M
 LOG_LEVEL: info
-AUTH_BASE: https://uat.hsesinfo.org
+AUTH_BASE: https://staging.hses.ohs.acf.hhs.gov
 # This env variable should go away soon in favor of TTA_SMART_HUB_URI
 REDIRECT_URI_HOST: https://tta-smarthub-dev.app.cloud.gov
 TTA_SMART_HUB_URI: https://tta-smarthub-dev.app.cloud.gov

--- a/deployment_config/prod_vars.yml
+++ b/deployment_config/prod_vars.yml
@@ -3,7 +3,7 @@ web_instances: 2
 web_memory: 512M
 worker_instances: 1
 worker_memory: 512M
-LOG_LEVEL: debug
+LOG_LEVEL: info
 AUTH_BASE: https://hses.ohs.acf.hhs.gov
 # This env variable should go away soon in favor of TTA_SMART_HUB_URI
 REDIRECT_URI_HOST: https://ttahub.ohs.acf.hhs.gov

--- a/deployment_config/sandbox_vars.yml
+++ b/deployment_config/sandbox_vars.yml
@@ -4,7 +4,7 @@ web_memory: 512M
 worker_instances: 1
 worker_memory: 512M
 LOG_LEVEL: info
-AUTH_BASE: https://uat.hsesinfo.org
+AUTH_BASE: https://staging.hses.ohs.acf.hhs.gov
 # This env variable should go away soon in favor of TTA_SMART_HUB_URI
 REDIRECT_URI_HOST: https://tta-smarthub-sandbox.app.cloud.gov
 TTA_SMART_HUB_URI: https://tta-smarthub-sandbox.app.cloud.gov

--- a/deployment_config/staging_vars.yml
+++ b/deployment_config/staging_vars.yml
@@ -4,7 +4,7 @@ web_memory: 512M
 worker_instances: 1
 worker_memory: 512M
 LOG_LEVEL: info
-AUTH_BASE: https://uat.hsesinfo.org
+AUTH_BASE: https://staging.hses.ohs.acf.hhs.gov
 # This env variable should go away soon in favor of TTA_SMART_HUB_URI
 REDIRECT_URI_HOST: https://tta-smarthub-staging.app.cloud.gov
 TTA_SMART_HUB_URI: https://tta-smarthub-staging.app.cloud.gov

--- a/src/app.js
+++ b/src/app.js
@@ -59,15 +59,23 @@ app.get(oauth2CallbackPath, async (req, res) => {
 
     const { url } = requestObj;
     const { data } = await axios.get(url, requestObj);
-    auditLogger.info(`User details response data: ${JSON.stringify(data, null, 2)}`);
-    const {
-      name,
-      principal: {
-        username,
-        userId,
-        authorities,
-      },
-    } = data;
+
+    logger.debug(`User details response data: ${JSON.stringify(data, null, 2)}`);
+
+    let name; let username; let userId; let
+      authorities;
+    if (data.principal.attributes) { // PIV card use response
+      name = data.name;
+      username = data.principal.attributes.user.username;
+      userId = data.principal.attributes.user.userId;
+      authorities = data.principal.attributes.user.authorities;
+    } else {
+      name = data.name;
+      username = data.principal.username;
+      userId = data.principal.userId;
+      authorities = data.principal.authorities;
+    }
+
     let email = null;
     if (isEmail(username)) {
       email = username;
@@ -84,8 +92,8 @@ app.get(oauth2CallbackPath, async (req, res) => {
     req.session.userId = dbUser.id;
     auditLogger.info(`User ${dbUser.id} logged in`);
 
-    logger.info(`referrer path: ${req.session.referrerPath}`);
-    res.redirect(join(process.env.TTA_SMART_HUB_URI, req.session.referrerPath));
+    logger.debug(`referrer path: ${req.session.referrerPath}`);
+    res.redirect(join(process.env.TTA_SMART_HUB_URI, req.session.referrerPath || ''));
   } catch (error) {
     auditLogger.error(`Error logging in: ${error}`);
     res.status(INTERNAL_SERVER_ERROR).end();

--- a/src/app.test.js
+++ b/src/app.test.js
@@ -1,0 +1,70 @@
+import request from 'supertest';
+import axios from 'axios';
+import app from './app';
+import { hsesAuth } from './middleware/authMiddleware';
+import userInfoClassicLogin from './mocks/classicLogin';
+import userInfoPivCardLogin from './mocks/pivCardLogin';
+import findOrCreateUser from './services/accessValidation';
+
+jest.mock('axios');
+jest.mock('./middleware/authMiddleware');
+jest.mock('./services/accessValidation');
+
+describe('TTA Hub server', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules(); // clear the cache
+    process.env = { ...ORIGINAL_ENV }; // make a copy
+
+    hsesAuth.code.getToken.mockResolvedValue({ sign: jest.fn().mockReturnValue({}) });
+    findOrCreateUser.mockResolvedValue({ id: 1 });
+  });
+
+  afterAll(async () => {
+    process.env = ORIGINAL_ENV; // restore original env
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('can handle oauth classic login user response from HSES', async () => {
+    // Ensure authorization is required, do not bypass authorization check
+    process.env.NODE_ENV = 'test';
+    process.env.BYPASS_AUTH = 'false';
+
+    const responseFromUserInfo = {
+      status: 200,
+      data: userInfoClassicLogin,
+    };
+    axios.get.mockResolvedValueOnce(responseFromUserInfo);
+
+    hsesAuth.code.getToken.mockResolvedValue({ sign: jest.fn().mockReturnValue({}) });
+
+    const resp = await request(app).get('/oauth2-client/login/oauth2/code/');
+    expect(findOrCreateUser).toHaveBeenCalledWith({
+      email: 'testUser@adhocteam.us', hsesAuthorities: ['ROLE_FEDERAL'], hsesUserId: '1', hsesUsername: 'testUser@adhocteam.us', name: 'testUser@adhocteam.us',
+    });
+    expect(resp.status).toBe(302);
+  });
+
+  test('can handle oauth piv card login user response from HSES', async () => {
+    // Ensure authorization is required, do not bypass authorization check
+    process.env.NODE_ENV = 'test';
+    process.env.BYPASS_AUTH = 'false';
+
+    const responseFromUserInfoPiv = {
+      status: 200,
+      data: userInfoPivCardLogin,
+    };
+    axios.get.mockResolvedValueOnce(responseFromUserInfoPiv);
+
+    const resp = await request(app).get('/oauth2-client/login/oauth2/code/');
+    expect(axios.get).toHaveBeenCalled();
+    expect(findOrCreateUser).toHaveBeenCalledWith({
+      email: 'testUser@adhocteam.us', hsesAuthorities: ['ROLE_FEDERAL'], hsesUserId: '1', hsesUsername: 'testUser@adhocteam.us', name: 'testUser@adhocteam.us',
+    });
+    expect(resp.status).toBe(302);
+  });
+});

--- a/src/mocks/classicLogin.js
+++ b/src/mocks/classicLogin.js
@@ -1,0 +1,100 @@
+const userInfoClassicLogin = {
+  authorities: [
+    {
+      authority: 'ROLE_FEDERAL',
+    },
+  ],
+  details: {
+    remoteAddress: '127.1.1.210',
+    sessionId: null,
+    tokenValue: 'test-e4b2-test-b016-test',
+    tokenType: 'Bearer',
+    decodedDetails: null,
+  },
+  authenticated: true,
+  userAuthentication: {
+    authorities: [
+      {
+        authority: 'ROLE_FEDERAL',
+      },
+    ],
+    details: {
+      remoteAddress: '127.1.1.210',
+      sessionId: '7E583D362871D9',
+    },
+    authenticated: true,
+    principal: {
+      password: null,
+      username: 'testUser@adhocteam.us',
+      authorities: [
+        {
+          authority: 'ROLE_FEDERAL',
+        },
+      ],
+      accountNonExpired: true,
+      accountNonLocked: true,
+      credentialsNonExpired: true,
+      enabled: true,
+      userId: 1,
+      grantAgencyId: null,
+      remoteAddress: '127.1.1.210',
+      authenticationStatus: 'Ok',
+      passwordExpired: false,
+    },
+    credentials: null,
+    name: 'testUser@adhocteam.us',
+  },
+  credentials: '',
+  principal: {
+    password: null,
+    username: 'testUser@adhocteam.us',
+    authorities: [
+      {
+        authority: 'ROLE_FEDERAL',
+      },
+    ],
+    accountNonExpired: true,
+    accountNonLocked: true,
+    credentialsNonExpired: true,
+    enabled: true,
+    userId: 1,
+    grantAgencyId: null,
+    remoteAddress: '127.1.1.210',
+    authenticationStatus: 'Ok',
+    passwordExpired: false,
+  },
+  oauth2Request: {
+    clientId: 'test-client-id',
+    scope: [
+      'user_info',
+    ],
+    requestParameters: {
+      code: 'TestCode',
+      grant_type: 'authorization_code',
+      scope: 'user_info',
+      response_type: 'code',
+      redirect_uri: 'http://localhost:8080/oauth2-client/login/oauth2/code/',
+      state: '',
+      client_id: 'test-client-id',
+    },
+    resourceIds: [],
+    authorities: [
+      {
+        authority: 'ROLE_TRUSTED_CLIENT',
+      },
+    ],
+    approved: true,
+    refresh: false,
+    redirectUri: 'http://localhost:8080/oauth2-client/login/oauth2/code/',
+    responseTypes: [
+      'code',
+    ],
+    extensions: {},
+    grantType: 'authorization_code',
+    refreshTokenRequest: null,
+  },
+  clientOnly: false,
+  name: 'testUser@adhocteam.us',
+};
+
+export default userInfoClassicLogin;

--- a/src/mocks/pivCardLogin.js
+++ b/src/mocks/pivCardLogin.js
@@ -1,0 +1,123 @@
+const userInfoPivCardLogin = {
+  authorities: [
+    {
+      authority: 'ROLE_FEDERAL',
+    },
+  ],
+  details: {
+    remoteAddress: '127.1.1.0',
+    sessionId: null,
+    tokenValue: 'test-f8d5-test-b4b6-test',
+    tokenType: 'Bearer',
+    decodedDetails: null,
+  },
+  authenticated: true,
+  userAuthentication: {
+    authorities: [
+      {
+        authority: 'ROLE_FEDERAL',
+      },
+    ],
+    details: {
+      remoteAddress: '127.1.1.0',
+      sessionId: 'A60A95A0D9A0',
+    },
+    authenticated: true,
+    principal: {
+      authorities: [
+        {
+          authority: 'ROLE_FEDERAL',
+        },
+      ],
+      attributes: {
+        name: 'testUser@adhocteam.us',
+        user: {
+          password: 'pswd',
+          username: 'testUser@adhocteam.us',
+          authorities: [
+            {
+              authority: 'ROLE_FEDERAL',
+            },
+          ],
+          accountNonExpired: true,
+          accountNonLocked: true,
+          credentialsNonExpired: true,
+          enabled: true,
+          userId: 1,
+          grantAgencyId: null,
+          remoteAddress: '127.1.1.0',
+          authenticationStatus: 'Ok',
+          passwordExpired: false,
+        },
+      },
+      name: 'testUser@adhocteam.us',
+    },
+    authorizedClientRegistrationId: 'piv',
+    credentials: '',
+    name: 'testUser@adhocteam.us',
+  },
+  credentials: '',
+  principal: {
+    authorities: [
+      {
+        authority: 'ROLE_FEDERAL',
+      },
+    ],
+    attributes: {
+      name: 'testUser@adhocteam.us',
+      user: {
+        password: 'pswd',
+        username: 'testUser@adhocteam.us',
+        authorities: [
+          {
+            authority: 'ROLE_FEDERAL',
+          },
+        ],
+        accountNonExpired: true,
+        accountNonLocked: true,
+        credentialsNonExpired: true,
+        enabled: true,
+        userId: 1,
+        grantAgencyId: null,
+        remoteAddress: '127.1.1.0',
+        authenticationStatus: 'Ok',
+        passwordExpired: false,
+      },
+    },
+    name: 'testUser@adhocteam.us',
+  },
+  oauth2Request: {
+    clientId: 'test-client-id',
+    scope: [
+      'user_info',
+    ],
+    requestParameters: {
+      code: 'code',
+      grant_type: 'authorization_code',
+      scope: 'user_info',
+      response_type: 'code',
+      redirect_uri: 'http://localhost:8080/oauth2-client/login/oauth2/code/',
+      state: '',
+      client_id: 'test-client-id',
+    },
+    resourceIds: [],
+    authorities: [
+      {
+        authority: 'ROLE_TRUSTED_CLIENT',
+      },
+    ],
+    approved: true,
+    refresh: false,
+    redirectUri: 'http://localhost:8080/oauth2-client/login/oauth2/code/',
+    responseTypes: [
+      'code',
+    ],
+    extensions: {},
+    refreshTokenRequest: null,
+    grantType: 'authorization_code',
+  },
+  clientOnly: false,
+  name: 'testUser@adhocteam.us',
+};
+
+export default userInfoPivCardLogin;


### PR DESCRIPTION
## Description of change
Adds support for the data format returned from the user-info endpoint from HSES for the PIV card user logins. After the HSES upgrade, while the username/password user logins worked, the PIV card users were not since the format of the data changed. This PR also points to the new HSES url for staging/dev/sandbox environments and disables the extra logging.


## How to test
On sandbox:
- verify that login into the hub works and the app behaves as expected

Or locally:
- update the .`env `file with the new HSES url (`AUTH_BASE=https://staging.hses.ohs.acf.hhs.gov`)
- set `BYPASS_AUTH=false`
- set the `AUTH_CLIENT_ID` and `AUTH_CLIENT_SECRET`  to new values (I'll send via keybase)
- verify that login into the hub works and the app behaves as expected


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-176


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
