### PR TITLE
Increase Prod app memory and instances

### DIFF
--- a/deployment_config/prod_vars.yml
+++ b/deployment_config/prod_vars.yml
@@ -1,6 +1,6 @@
 env: prod
-web_instances: 2
-web_memory: 512M
+web_instances: 3
+web_memory: 1GB
 worker_instances: 1
 worker_memory: 512M
 LOG_LEVEL: info

--- a/deployment_config/prod_vars.yml
+++ b/deployment_config/prod_vars.yml
@@ -1,6 +1,6 @@
 env: prod
 web_instances: 3
-web_memory: 1GB
+web_memory: 2GB
 worker_instances: 1
 worker_memory: 512M
 LOG_LEVEL: info


### PR DESCRIPTION
## Description of change
- Increase application memory size as a quick, bandaid resolution to try to allow user to access R04-AR-8098. ~We're unsure that this will be enough memory for report to be accessed, but it is the limit allowed by [cloud foundry](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#memory)~ Likely misread the inflection on that sentence. :) 
- Requests to access above report at current memory size crash the application instance, because application startup time is quick but not insignificant, mult requests have the ability to crash all instances before a new instance comes online. Increase instance size will make this scenario less likely.
- This brings our total application memory allocation from 4.5GB to 6.5GB


## How to test
Prod specific deployment changes are untested, but this is a relatively straightforward change. If mistakes are made here, application will simply fail to launch. Old production instances are not stopped until new instances are running and deemed healthy (aws autoscaling). Therefore, any unforeseen mistakes should not cause any impact to running application.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-178


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [no] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
