### PR TITLE
Show tta overview widget to admins only

### DIFF
--- a/frontend/src/pages/Landing/__tests__/index.js
+++ b/frontend/src/pages/Landing/__tests__/index.js
@@ -255,6 +255,10 @@ describe('Landing Page sorting', () => {
           scopeId: 3,
           regionId: 1,
         },
+        {
+          scopeId: 2,
+          regionId: 1,
+        },
       ],
     };
 
@@ -474,6 +478,10 @@ describe('Landing page table menus & selections', () => {
             scopeId: 3,
             regionId: 1,
           },
+          {
+            scopeId: 2,
+            regionId: 1,
+          },
         ],
       };
 
@@ -682,6 +690,10 @@ describe('Landing page table menus & selections', () => {
               scopeId: 3,
               regionId: 1,
             },
+            {
+              scopeId: 2,
+              regionId: 1,
+            },
           ],
         };
 
@@ -741,6 +753,10 @@ describe('My alerts sorting', () => {
       permissions: [
         {
           scopeId: 3,
+          regionId: 1,
+        },
+        {
+          scopeId: 2,
           regionId: 1,
         },
       ],

--- a/frontend/src/pages/Landing/index.js
+++ b/frontend/src/pages/Landing/index.js
@@ -23,7 +23,7 @@ import 'uswds/dist/css/uswds.css';
 import '@trussworks/react-uswds/lib/index.css';
 import './index.css';
 import MyAlerts from './MyAlerts';
-import { hasReadWrite, allRegionsUserHasPermissionTo } from '../../permissions';
+import isAdmin, { hasReadWrite, allRegionsUserHasPermissionTo } from '../../permissions';
 import { REPORTS_PER_PAGE, ALERTS_PER_PAGE } from '../../Constants';
 import Filter, { filtersToQueryString } from './Filter';
 import ReportMenu from './ReportMenu';
@@ -493,7 +493,7 @@ function Landing() {
                 <h1 className="landing">Activity Reports</h1>
               </Grid>
               <Grid col={2} className="flex-align-self-center">
-                {getUserRegions(user).length > 1
+                {isAdmin(user) && getUserRegions(user).length > 1
                 && (
                 <RegionalSelect
                   regions={allRegionsUserHasPermissionTo(user)}
@@ -509,12 +509,14 @@ function Landing() {
             </Grid>
             <Grid row gap className="smart-hub--overview">
               <Grid col={10}>
+                {isAdmin(user) && (
                 <Overview
                   filters={filters}
                   region={appliedRegion}
                   allRegions={getUserRegions(user)}
                   skipLoading
                 />
+                )}
               </Grid>
             </Grid>
             <Grid row>


### PR DESCRIPTION
## Description of change
We got a request to turn off the tta overview widgets to analyze the statistics. This PR enables viewing of the TTA overview widget for admins only.


## How to test
- pull changes
- start the server as an admin, e.g. Hermione (user 1) by editing `.env`  - `CURRENT_USER_ID=1`
- note that the tta overview widget is showing
- remove the admin access by going to the admin UI
- navigate to activity reports
- refresh the page
- verify that neither the widget nor button displays
- start the server as yourself with admin access
- enable admin access for the previous user

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-143


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [n/a] Meets issue criteria
- [n/a] JIRA ticket status updated
- [n/a] Code is meaningfully tested
- [ n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ n/a] API Documentation updated
- [n/a ] Boundary diagram updated
- [n/a ] Logical Data Model updated
- [ n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
