### PR TITLE
Attempt to specify nodejs buildpack version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,7 @@ parameters:
     default: "main"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
-    default: "TTAHUB-174/update-list-of-topics"
+    default: "js-specify-buildpack-version"
     type: string
   prod_new_relic_app_id:
     default: "877570491"

--- a/bin/ping-server
+++ b/bin/ping-server
@@ -3,12 +3,12 @@
 attempt_counter=0
 max_attempts=10
 
-until $(curl --output /dev/null --max-time 5 --silent --head --fail http://localhost:3000); do
+until $(curl --output /dev/null --max-time 10 --silent --head --fail http://localhost:3000); do
     if [ ${attempt_counter} -eq ${max_attempts} ];then
       echo "Max attempts reached"
       exit 1
     fi
 
     attempt_counter=$(($attempt_counter+1))
-    sleep 5
+    sleep 10
 done

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,7 @@
 applications:
   - name: tta-smarthub-((env))
     buildpacks:
-      - nodejs_buildpack
+      - https://github.com/cloudfoundry/nodejs-buildpack.git#v1.7.54
     env:
       AUTH_BASE: ((AUTH_BASE))
       AUTH_CLIENT_ID: ((AUTH_CLIENT_ID))


### PR DESCRIPTION
## Description of change

A recent nodejs buildpack update  (`1.7.54` -> `1.7.56`) is incompatible with the version of node used by the application. We use node `14.16.1` which is no longer supported by buildpack `1.7.56`. To prevent this from happening in the future and allow us to investigate the nodejs version update in a more controlled way we now try to explicitly set the buildpack version.

## How to test

Verify deploy to sandbox is successful

## Checklists

### Every PR

<!-- Add details to each completed item -->
- ~[ ] Meets issue criteria~
- ~[ ] JIRA ticket status updated~
- ~[ ] Code is meaningfully tested~
- ~[ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)~
- ~[ ] API Documentation updated~
- ~[ ] Boundary diagram updated~
- ~[ ] Logical Data Model updated~
- ~[ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
