### PR TITLE
Fix overview multi request

### DIFF
--- a/frontend/src/widgets/withWidgetData.js
+++ b/frontend/src/widgets/withWidgetData.js
@@ -19,12 +19,13 @@ const withWidgetData = (Widget, widgetId) => {
       region, allRegions, loadingOverride, skipLoading, errorOverride,
     } = props;
 
+    const selectedRegion = region || allRegions[0];
+
     useEffect(() => {
       const fetch = async () => {
         try {
           updateLoading(true);
-          const requestedRegion = region || allRegions[0];
-          const fetchedData = await fetchWidget(widgetId, requestedRegion);
+          const fetchedData = await fetchWidget(widgetId, selectedRegion);
           updateData(fetchedData);
           updateError('');
         } catch (e) {
@@ -34,7 +35,7 @@ const withWidgetData = (Widget, widgetId) => {
         }
       };
       fetch();
-    }, [region, allRegions]);
+    }, [selectedRegion]);
 
     if ((loading || loadingOverride) && !skipLoading) {
       return (


### PR DESCRIPTION
## Description of change

Overview widget no longer calls the API multiple times. Passing a complex object to a dependency array causes re-renders even when the arrays are "equal". We will want to revisit `withWidgetData` in the future when we want to add more filtering conditions. Would be nice to figure out the interface now so we don't have a bunch of widgets to update in the future.

## How to test

1) Checkout main
2) Go to the `Activity Reports` page with a network monitor open. Note multiple overview widget requests to the API
3) Checkout `js-fix-overview-multi-request`
4) Reload `Activity Reports`, note a single overview widget request

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [n/a] Meets issue criteria
- [n/a] JIRA ticket status updated
- [n/a] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [n/a] Update JIRA ticket status
