### PR TITLE
Add default ordering to users

### DIFF
--- a/src/models/tests/user.test.js
+++ b/src/models/tests/user.test.js
@@ -1,0 +1,54 @@
+import db, { User } from '..';
+
+describe('Users model', () => {
+  afterAll(async () => {
+    await db.sequelize.close();
+  });
+
+  const ids = [60, 61, 62, 63];
+
+  describe('default scope', () => {
+    const users = [
+      {
+        id: 60,
+        name: 'd',
+      },
+      {
+        id: 61,
+        name: 'c',
+      },
+      {
+        id: 62,
+        name: 'a',
+      },
+      {
+        id: 63,
+        name: 'b',
+      },
+    ];
+
+    beforeEach(async () => {
+      await Promise.all(
+        users.map((u) => User.create({
+          id: u.id,
+          name: u.name,
+          hsesUsername: u.id,
+          hsesUserId: u.id,
+        })),
+      );
+    });
+
+    afterEach(async () => {
+      await User.destroy({ where: { id: ids } });
+    });
+
+    it('Properly orders users', async () => {
+      const expected = ['a', 'b', 'c', 'd'];
+      const foundUsers = await User.findAll({
+        where: { id: ids },
+      });
+      const names = foundUsers.map((u) => u.name);
+      expect(names).toEqual(expected);
+    });
+  });
+});

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -89,6 +89,11 @@ export default (sequelize, DataTypes) => {
     },
     lastLogin: DataTypes.DATE,
   }, {
+    defaultScope: {
+      order: [
+        [sequelize.fn('CONCAT', sequelize.col('name'), sequelize.col('email')), 'ASC'],
+      ],
+    },
     sequelize,
     modelName: 'User',
   });


### PR DESCRIPTION
## Description of change
Users are now ordered by name and email. Added the email in case the user has no name. Their email address will _probably_ be ordered close to where the user should be because the email address usually starts with the user's first name.

## How to test

1) Verify users are ordered in the AR collaborators multi-select
2) Verify users are ordered on the admin UI
3) Add some approvers via the admin page and verify users are ordered in the AR approving manager multi-select

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-158

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
