### PR TITLE
GetWidgets API call handles errors

### DIFF
--- a/src/routes/widgets/handlers.js
+++ b/src/routes/widgets/handlers.js
@@ -1,36 +1,47 @@
 /* eslint-disable import/prefer-default-export */
 import widgets from '../../widgets';
 import { filtersToScopes } from '../../scopes/activityReport';
+import handleErrors from '../../lib/apiErrorHandler';
 import { setReadRegions } from '../../services/accessValidation';
 import { onlyAllowedKeys, formatQuery } from './utils';
 
+const namespace = 'SERVICE:WIDGETS';
+
+const logContext = {
+  namespace,
+};
+
 export async function getWidget(req, res) {
-  const { widgetId } = req.params;
-  const getWidgetData = widgets[widgetId];
+  try {
+    const { widgetId } = req.params;
+    const getWidgetData = widgets[widgetId];
 
-  if (!getWidgetData) {
-    res.sendStatus(404);
-    return;
-  }
+    if (!getWidgetData) {
+      res.sendStatus(404);
+      return;
+    }
 
-  // This returns the query object with "region" property filtered by user permissions
-  const query = await setReadRegions(req.query, req.session.userId, true);
+    // This returns the query object with "region" property filtered by user permissions
+    const query = await setReadRegions(req.query, req.session.userId, true);
 
-  // convert the query to scopes
-  const scopes = filtersToScopes(query);
+    // convert the query to scopes
+    const scopes = filtersToScopes(query);
 
-  // filter out any disallowed keys
-  const queryWithFilteredKeys = onlyAllowedKeys(query);
+    // filter out any disallowed keys
+    const queryWithFilteredKeys = onlyAllowedKeys(query);
 
-  /**
+    /**
    * Proposal: This is where we should do things like format values in the query object
    * if we need special formatting, a la parsing the region for use in string literals   *
    */
 
-  const formattedQueryWithFilteredKeys = formatQuery(queryWithFilteredKeys);
+    const formattedQueryWithFilteredKeys = formatQuery(queryWithFilteredKeys);
 
-  // pass in the scopes and the query
-  const widgetData = await getWidgetData(scopes, formattedQueryWithFilteredKeys);
+    // pass in the scopes and the query
+    const widgetData = await getWidgetData(scopes, formattedQueryWithFilteredKeys);
 
-  res.json(widgetData);
+    res.json(widgetData);
+  } catch (error) {
+    handleErrors(req, res, error, logContext);
+  }
 }

--- a/src/widgets/totalHrsAndGranteeGraph.js
+++ b/src/widgets/totalHrsAndGranteeGraph.js
@@ -26,8 +26,21 @@ function addOrUpdateResponse(traceIndex, res, xValue, valueToAdd) {
 }
 
 export default async function totalHrsAndGranteeGraph(scopes, query) {
+  // Build out return Graph data.
+  const res = [
+    { name: 'All Dates', x: [], y: [] },
+    { name: 'Grantee Rec TTA', x: [], y: [] },
+    { name: 'Hours of Training', x: [], y: [] },
+    { name: 'Hours of Technical Assistance', x: [], y: [] },
+    { name: 'Hours of Both', x: [], y: [] }];
+
   // Get the Date Range.
   const dateRange = query['startDate.win'];
+
+  if (!dateRange) {
+    return res;
+  }
+
   const dates = dateRange.split('-');
 
   // Parse out Start and End Date.
@@ -97,14 +110,6 @@ export default async function totalHrsAndGranteeGraph(scopes, query) {
     ],
     order: [['startDate', 'ASC']],
   });
-
-  // Build out return Graph data.
-  const res = [
-    { name: 'All Dates', x: [], y: [] },
-    { name: 'Grantee Rec TTA', x: [], y: [] },
-    { name: 'Hours of Training', x: [], y: [] },
-    { name: 'Hours of Technical Assistance', x: [], y: [] },
-    { name: 'Hours of Both', x: [], y: [] }];
 
   const arDates = [];
   const usedDates = [];

--- a/src/widgets/totalHrsAndGranteeGraph.test.js
+++ b/src/widgets/totalHrsAndGranteeGraph.test.js
@@ -112,6 +112,13 @@ describe('Total Hrs and Grantee Graph widget', () => {
     jest.clearAllMocks();
   });
 
+  it('handles no filters', async () => {
+    const query = { };
+    const scopes = filtersToScopes(query);
+    const data = await totalHrsAndGranteeGraph(scopes, query);
+    expect(data.length).toBe(5);
+  });
+
   it('retrieves line graph data by month', async () => {
     // Outside of Start Date bounds.
     const reportOne = await ActivityReport.findOne({ where: { duration: 1, startDate: '2021-01-03' } });


### PR DESCRIPTION
## Description of change

Unhanded exceptions in handlers never return, which causes a long wait until the request times out. This causes some issues with the frontend (when the request should have errored out immediately). `GetWidgets` now handles errors. Also the `totalHrs...` widget handles the case were a time frame is not specified.

Async errors are handled automagically in express 5 but not in 4, https://expressjs.com/en/guide/error-handling.html. We should think about upgrading to express 5 so we don't run into this situation again if we forget to manually handle errors in a handler.

## How to test

1) Pull down
2) Open the dashboard page with the network monitor open. Note the first `TotalHrs...` widget API call returns with a 200

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-258

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [n/a] Meets issue criteria
- [n/a] JIRA ticket status updated
- [x] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
