### PR TITLE
fix incorrect participant count for all regions

### DIFF
--- a/src/widgets/overview.js
+++ b/src/widgets/overview.js
@@ -13,7 +13,7 @@ import { REPORT_STATUSES } from '../constants';
   If adding a new widget be sure to add the widget to ./index.js
 */
 export default async function overview(scopes, query) {
-  const { region } = query;
+  const region = query['region.in'];
   const startDte = '2020-09-15';
   const grantsWhere = `WHERE "regionId" in (${region !== undefined ? region : '0'}) and "endDate" >= '${startDte}'`;
   const baseWhere = `${grantsWhere} AND "status" = '${REPORT_STATUSES.APPROVED}' AND "startDate" >= '${startDte}'`;


### PR DESCRIPTION
## Description of change
The participant count as well as the total tta hours did not show the correct number when the "All regions" option was selected for the TTA Overview widget on the activity reports page. This PR fixes it.


## How to test
- pull changes
- create several reports in different regions
- verify that the "All regions" option shows the correct value (previously it would show the number for the first region only)

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
