### PR TITLE
[TTAHUB-215] Regional Dashboard: Add accessibility option for TTA Hours graph

### DIFF
--- a/frontend/src/widgets/AccessibleWidgetData.css
+++ b/frontend/src/widgets/AccessibleWidgetData.css
@@ -1,0 +1,7 @@
+.ttahub--accessible-widget-data  {
+    width: 100%;
+}
+
+.ttahub--accessible-widget-data th[scope="row"] {
+    font-weight: bold;
+}

--- a/frontend/src/widgets/AccessibleWidgetData.js
+++ b/frontend/src/widgets/AccessibleWidgetData.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { v4 as uuidv4 } from 'uuid';
+import './AccessibleWidgetData.css';
+
+export default function AccessibleWidgetData({ caption, columnHeadings, rows }) {
+  function renderRow(row) {
+    return (
+      <tr key={uuidv4()}>
+        { row.heading ? <th scope="row">{row.heading}</th> : null }
+        { row.data.map((rowData) => <td key={uuidv4()}>{rowData}</td>)}
+      </tr>
+    );
+  }
+
+  return (
+    <table className="ttahub--accessible-widget-data usa-table usa-table--borderless usa-table--striped">
+      <caption className="sr-only">
+        {caption}
+      </caption>
+      <thead>
+        <tr>
+          {columnHeadings.map((heading) => <th key={uuidv4()} scope="col">{heading}</th>)}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => renderRow(row))}
+      </tbody>
+    </table>
+  );
+}
+
+AccessibleWidgetData.propTypes = {
+  caption: PropTypes.string.isRequired,
+  columnHeadings: PropTypes.arrayOf(PropTypes.string).isRequired,
+  rows: PropTypes.arrayOf(PropTypes.shape({
+    heading: PropTypes.string,
+    data: PropTypes.arrayOf(PropTypes.string),
+  })).isRequired,
+};

--- a/frontend/src/widgets/TotalHrsAndGranteeGraph.css
+++ b/frontend/src/widgets/TotalHrsAndGranteeGraph.css
@@ -1,3 +1,8 @@
+.ttahub--show-accessible-data-button {
+  flex: 1;
+  text-align: right;
+}
+
 .ttahub--total-hrs-grantee-graph-legend {
   text-align: center;
 }

--- a/frontend/src/widgets/__tests__/TotalHrsAndGranteeGraph.js
+++ b/frontend/src/widgets/__tests__/TotalHrsAndGranteeGraph.js
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { TotalHrsAndGranteeGraph } from '../TotalHrsAndGranteeGraph';
 
 const TEST_DATA_MONTHS = [
@@ -19,7 +19,7 @@ const TEST_DATA_DAYS = [
 
 const renderTotalHrsAndGranteeGraph = async (props) => (
   render(
-    <TotalHrsAndGranteeGraph data={props.data} dateTime={{ dateInExpectedFormat: '', prettyPrintedQuery: '05/27/1967-08/21/1968' }} />,
+    <TotalHrsAndGranteeGraph data={props.data} dateTime={{ timestamp: '', label: '05/27/1967-08/21/1968' }} />,
   )
 );
 
@@ -81,5 +81,30 @@ describe('Total Hrs And Grantee Graph Widget', () => {
     renderTotalHrsAndGranteeGraph({ data });
 
     expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('handles switching contexts', async () => {
+    renderTotalHrsAndGranteeGraph({ data: TEST_DATA_MONTHS });
+    const button = screen.getByRole('button', { name: /show accessible data/i });
+    fireEvent.click(button);
+    const table = screen.getByRole('table', { name: /total tta hours by date and type/i });
+
+    const randomRowHeader = screen.getByRole('rowheader', { name: /grantee rec tta/i });
+    expect(randomRowHeader).toBeInTheDocument();
+    const randomColumnHeader = screen.getByRole('columnheader', { name: /apr/i });
+    expect(randomColumnHeader).toBeInTheDocument();
+
+    const cells = [];
+
+    // eslint-disable-next-line no-plusplus
+    for (let index = 1; index < 15; index++) {
+      cells.push(screen.getByRole('cell', { name: index.toString() }));
+    }
+
+    cells.forEach((cell) => expect(cell).toBeInTheDocument());
+
+    expect(table).toBeInTheDocument();
+    fireEvent.click(button);
+    expect(table).not.toBeInTheDocument();
   });
 });

--- a/src/widgets/totalHrsAndGranteeGraph.js
+++ b/src/widgets/totalHrsAndGranteeGraph.js
@@ -39,9 +39,9 @@ export default async function totalHrsAndGranteeGraph(scopes, query) {
   // Build out return Graph data.
   const res = [
     { name: 'Grantee Rec TTA', x: [], y: [] },
-    { name: 'Hours of Training', x: [], y: [] },
-    { name: 'Hours of Technical Assistance', x: [], y: [] },
-    { name: 'Hours of Both', x: [], y: [] },
+    { name: 'Training', x: [], y: [] },
+    { name: 'Technical Assistance', x: [], y: [] },
+    { name: 'Both', x: [], y: [] },
   ];
 
   // Get the Date Range.


### PR DESCRIPTION
## Description of change

Add a button that toggles the TTA Hours Widget between being a graph and a table.

## How to test
Visit the regional dashboard page. Click on the link that says "view accessible data" next to the title and time on the TTA Hours widget. Note that the data changes and is correct.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-215

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
