### PR TITLE
Frontend test optimization (ENOMEM)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,7 +234,7 @@ jobs:
       - store_artifacts:
           path: coverage/
   test_frontend:
-    executor: docker-postgres-executor
+    executor: docker-executor
     steps:
       - attach_workspace:
           at: .

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,7 +56,7 @@
     "build": "INLINE_RUNTIME_CHUNK=false react-scripts build && mv build/ ../build/server/client",
     "eject": "react-scripts eject",
     "test": "cross-env TZ=America/New_York react-scripts test",
-    "test:ci": "cross-env JEST_JUNIT_OUTPUT_DIR=reports JEST_JUNIT_OUTPUT_NAME=unit.xml CI=true yarn test --coverage --reporters=default --reporters=jest-junit --logHeapUsage",
+    "test:ci": "cross-env TZ=America/New_York JEST_JUNIT_OUTPUT_DIR=reports JEST_JUNIT_OUTPUT_NAME=unit.xml CI=true node --expose-gc ./node_modules/.bin/react-scripts test --coverage --reporters=default --reporters=jest-junit --logHeapUsage",
     "lint": "eslint src",
     "lint:fix": "eslint --fix src",
     "lint:ci": "eslint -f eslint-formatter-multiple src"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,7 +56,7 @@
     "build": "INLINE_RUNTIME_CHUNK=false react-scripts build && mv build/ ../build/server/client",
     "eject": "react-scripts eject",
     "test": "cross-env TZ=America/New_York react-scripts test",
-    "test:ci": "cross-env JEST_JUNIT_OUTPUT_DIR=reports JEST_JUNIT_OUTPUT_NAME=unit.xml CI=true yarn test --coverage --reporters=default --reporters=jest-junit",
+    "test:ci": "cross-env JEST_JUNIT_OUTPUT_DIR=reports JEST_JUNIT_OUTPUT_NAME=unit.xml CI=true yarn test --coverage --reporters=default --reporters=jest-junit --logHeapUsage",
     "lint": "eslint src",
     "lint:fix": "eslint --fix src",
     "lint:ci": "eslint -f eslint-formatter-multiple src"


### PR DESCRIPTION
## Description of change

Our CI executor has 2 CPUs + 4 GB of RAM, which is fairly resource-constrained compared to developer computers. We are seeing the `test_frontend` job fail pretty frequently with `ENOMEM` errors due to Jest attempting to do more than the poor CI executor can handle. This PR does two things to attempt to help:

**1. Run Jest with `--logHeapUsage` and `--expose-gc`**

Recommended by [this article](https://dev.to/pustovalov_p/reducing-jest-memory-usage-1ina), the idea here is that we can get Jest to invoke the Node garbage collector after each test to keep peak memory usage down.

**2. Don't spin up Postgres to support frontend tests**

I switched the executor from `docker-postgres-executor` to `docker-executor` on the theory that Postgres was occupying some amount of RAM that Jest would prefer to slurp up.

## How to test

Run CI pipelines over and over and see if they fail due to `ENOMEM`. I've done [5 runs so far on 2aa6adf](https://app.circleci.com/pipelines/github/adhocteam/Head-Start-TTADP?branch=frontend-test-optimization) without a failure due to `ENOMEM`.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-114 (relates to this one)

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [n/a ] Meets issue criteria
- [n/a] JIRA ticket status updated
- [n/a] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [n/a] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
