### PR TITLE
Save grant/program specialists name and email to grants

### DIFF
--- a/src/lib/updateGrantsGrantees.test.js
+++ b/src/lib/updateGrantsGrantees.test.js
@@ -112,6 +112,15 @@ describe('Update grants and grantees', () => {
     expect(grant.programSpecialistEmail).toBe(null);
   });
 
+  it('should have null for grant/program specialists names if null from HSES', async () => {
+    await processFiles();
+    const grant = await Grant.findOne({ where: { number: '90CI4444' } });
+    expect(grant.programSpecialistName).toBe(null);
+    expect(grant.programSpecialistEmail).toBe(null);
+    expect(grant.grantSpecialistName).toBe(null);
+    expect(grant.grantSpecialistEmail).toBe(null);
+  });
+
   it('should not exclude grantees with only inactive grants', async () => {
     await processFiles();
     const grantee = await Grantee.findOne({ where: { id: 119 } });

--- a/src/lib/updateGrantsGrantees.test.js
+++ b/src/lib/updateGrantsGrantees.test.js
@@ -98,6 +98,20 @@ describe('Update grants and grantees', () => {
     expect(totalGrants.length).toBe(11);
   });
 
+  it('includes the grant specialists name and email', async () => {
+    await processFiles();
+    const grant = await Grant.findOne({ where: { number: '02CH01111' } });
+    expect(grant.grantSpecialistName).toBe('grant');
+    expect(grant.grantSpecialistEmail).toBe('grant@test.org');
+  });
+
+  it('includes the program specialists name and email', async () => {
+    await processFiles();
+    const grant = await Grant.findOne({ where: { number: '02CH01111' } });
+    expect(grant.programSpecialistName).toBe('program specialists');
+    expect(grant.programSpecialistEmail).toBe(null);
+  });
+
   it('should not exclude grantees with only inactive grants', async () => {
     await processFiles();
     const grantee = await Grantee.findOne({ where: { id: 119 } });

--- a/src/migrations/20210908164843-add_grant_program_specialist_to_grant.js
+++ b/src/migrations/20210908164843-add_grant_program_specialist_to_grant.js
@@ -1,0 +1,39 @@
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    queryInterface.sequelize.transaction(
+      async (transaction) => {
+        await queryInterface.addColumn(
+          'Grants',
+          'programSpecialistName',
+          { type: Sequelize.DataTypes.STRING },
+          { transaction },
+        );
+        await queryInterface.addColumn(
+          'Grants',
+          'programSpecialistEmail',
+          { type: Sequelize.DataTypes.STRING },
+          { transaction },
+        );
+        await queryInterface.addColumn(
+          'Grants',
+          'grantSpecialistName',
+          { type: Sequelize.DataTypes.STRING },
+          { transaction },
+        );
+        await queryInterface.addColumn(
+          'Grants',
+          'grantSpecialistEmail',
+          { type: Sequelize.DataTypes.STRING },
+          { transaction },
+        );
+      },
+    );
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.removeColumn('Grants', 'programSpecialistName');
+    await queryInterface.removeColumn('Grants', 'programSpecialistEmail');
+    await queryInterface.removeColumn('Grants', 'grantSpecialistName');
+    await queryInterface.removeColumn('Grants', 'grantSpecialistEmail');
+  },
+};

--- a/src/models/grant.js
+++ b/src/models/grant.js
@@ -35,6 +35,10 @@ module.exports = (sequelize, DataTypes) => {
     },
     cdi: DataTypes.BOOLEAN,
     status: DataTypes.STRING,
+    grantSpecialistName: DataTypes.STRING,
+    grantSpecialistEmail: DataTypes.STRING,
+    programSpecialistName: DataTypes.STRING,
+    programSpecialistEmail: DataTypes.STRING,
     startDate: DataTypes.DATE,
     endDate: DataTypes.DATE,
     granteeId: {

--- a/temp/grant_award.xml
+++ b/temp/grant_award.xml
@@ -75,6 +75,11 @@
   <program_acronym>CH</program_acronym>
   <grantee_name>Agency 1, Inc.</grantee_name>
   <grant_status>Active</grant_status>
+  <grants_specialist_first_name>grant</grants_specialist_first_name>
+  <grants_specialist_last_name xsi:nil="true"/>
+  <grants_specialist_email>grant@test.org</grants_specialist_email>
+  <program_specialist_first_name>program</program_specialist_first_name>
+  <program_specialist_last_name>specialists</program_specialist_last_name>
 </grant_award>
 <grant_award>
   <grant_award_id>5151</grant_award_id>


### PR DESCRIPTION
## Description of change

HSES data includes grant/program specialists names and emails. We now attach this data to grants in our database. This will allow us to display and filter on the specialists attached to the grant.

## How to test

Verify tests pass.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-327

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
