### PR TITLE
[TTAHUB-298] create basic grantee record page and route

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -31,6 +31,7 @@ import RequestPermissions from './components/RequestPermissions';
 import AriaLiveContext from './AriaLiveContext';
 import AriaLiveRegion from './components/AriaLiveRegion';
 import ApprovedActivityReport from './pages/ApprovedActivityReport';
+import GranteeRecord from './pages/GranteeRecord';
 
 function App() {
   const [user, updateUser] = useState();
@@ -124,13 +125,19 @@ function App() {
           )}
         />
         {enableWidgets && (
-          <Route
-            path="/widgets"
-            render={() => (
-              <Widgets />
-            )}
-          />
+        <Route
+          path="/widgets"
+          render={() => (
+            <Widgets />
+          )}
+        />
         )}
+        <Route
+          path="/region/:regionId/grantee/:granteeId"
+          render={({ match }) => (
+            <GranteeRecord match={match} user={user} />
+          )}
+        />
         <Route
           exact
           path="/regional-dashboard"
@@ -139,14 +146,14 @@ function App() {
           )}
         />
         {admin && (
-          <>
-            <Route
-              path="/admin"
-              render={() => (
-                <Admin />
-              )}
-            />
-          </>
+        <>
+          <Route
+            path="/admin"
+            render={() => (
+              <Admin />
+            )}
+          />
+        </>
         )}
         <Route
           render={() => <NotFound />}

--- a/frontend/src/fetchers/__tests__/grantee.js
+++ b/frontend/src/fetchers/__tests__/grantee.js
@@ -1,0 +1,19 @@
+import join from 'url-join';
+import fetchMock from 'fetch-mock';
+import { getGrantee } from '../grantee';
+
+const granteeUrl = join('/', 'api', 'grantee');
+
+describe('grantee fetcher', () => {
+  beforeEach(() => fetchMock.reset());
+  it('test that it retrieves a grantee', async () => {
+    const url = join(granteeUrl, '1', '?region=1');
+    fetchMock.getOnce(url, { name: 'Tim Johnson the Grantee' });
+    const res = await getGrantee(1, 1);
+    expect(res.name).toBe('Tim Johnson the Grantee');
+  });
+  it('tests that it requires a int for grantee id', async () => {
+    const res = await getGrantee('tim');
+    expect(res).toStrictEqual({});
+  });
+});

--- a/frontend/src/fetchers/grantee.js
+++ b/frontend/src/fetchers/grantee.js
@@ -1,0 +1,22 @@
+import join from 'url-join';
+import {
+  get,
+} from './index';
+import { DECIMAL_BASE } from '../Constants';
+
+const granteeUrl = join('/', 'api', 'grantee');
+
+// eslint-disable-next-line import/prefer-default-export
+export const getGrantee = async (granteeId, regionId = '') => {
+  try {
+    const regionSearch = regionId ? `?region=${regionId.toString(DECIMAL_BASE)}` : '';
+    const grantee = await get(
+      // convert to string after checking it's an int, this way it'll throw to the
+      // catch if not a parseable int
+      join(granteeUrl, parseInt(granteeId, DECIMAL_BASE).toString(DECIMAL_BASE), regionSearch),
+    );
+    return grantee.json();
+  } catch (e) {
+    return {};
+  }
+};

--- a/frontend/src/pages/GranteeRecord/__tests__/index.js
+++ b/frontend/src/pages/GranteeRecord/__tests__/index.js
@@ -1,0 +1,60 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import {
+  render, screen, waitFor,
+} from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
+import fetchMock from 'fetch-mock';
+import GranteeRecord from '../index';
+
+describe('grantee record page', () => {
+  const user = {
+    id: 2,
+    permissions: [
+      {
+        regionId: 45,
+        userId: 2,
+        scopeId: 1,
+      },
+      {
+        regionId: 45,
+        userId: 2,
+        scopeId: 2,
+      },
+      {
+        regionId: 45,
+        userId: 2,
+        scopeId: 3,
+      },
+    ],
+  };
+
+  function renderGranteeRecord() {
+    const match = {
+      path: '',
+      url: '',
+      params: {
+        granteeId: 1,
+        regionId: 45,
+      },
+    };
+
+    render(<GranteeRecord user={user} match={match} />);
+  }
+
+  beforeEach(() => {
+    fetchMock.get('/api/user', user);
+    fetchMock.get('/api/grantee/1?region=45', { name: 'Charles the Grantee' });
+  });
+  afterEach(() => {
+    fetchMock.restore();
+  });
+
+  it('shows the subtitle and grantee name', async () => {
+    act(() => renderGranteeRecord());
+    expect(screen.getByText(/grantee tta record/i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('Charles the Grantee - Region 45')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/GranteeRecord/index.js
+++ b/frontend/src/pages/GranteeRecord/index.js
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import ReactRouterPropTypes from 'react-router-prop-types';
+import { DECIMAL_BASE } from '../../Constants';
+import { getGrantee } from '../../fetchers/grantee';
+
+export default function GranteeRecord({ match }) {
+  const [granteeName, setGranteeName] = useState(` - Region ${match.params.regionId}`);
+
+  useEffect(() => {
+    try {
+      const granteeId = parseInt(match.params.granteeId, DECIMAL_BASE);
+      const regionId = parseInt(match.params.regionId, DECIMAL_BASE);
+
+      getGrantee(granteeId, regionId).then((grantee) => {
+        setGranteeName(`${grantee.name} - Region ${regionId}`);
+      });
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.log(err);
+    }
+  }, [match.params]);
+
+  return (
+    <>
+      <span>Grantee TTA Record</span>
+      <h1 className="landing margin-top-1">{granteeName}</h1>
+    </>
+  );
+}
+
+GranteeRecord.propTypes = {
+  match: ReactRouterPropTypes.match.isRequired,
+  user: PropTypes.shape({
+    id: PropTypes.number,
+    name: PropTypes.string,
+    role: PropTypes.arrayOf(PropTypes.string),
+  }).isRequired,
+};

--- a/src/routes/apiDirectory.js
+++ b/src/routes/apiDirectory.js
@@ -11,6 +11,7 @@ import { userById } from '../services/users';
 import { auditLogger } from '../logger';
 import handleErrors from '../lib/apiErrorHandler';
 import adminRouter from './admin';
+import granteeRouter from './grantee';
 
 export const loginPath = '/login';
 
@@ -24,8 +25,8 @@ router.use('/admin', adminRouter);
 router.use('/activity-reports', activityReportsRouter);
 router.use('/users', usersRouter);
 router.use('/widgets', widgetsRouter);
-
 router.use('/files', filesRouter);
+router.use('/grantee', granteeRouter);
 
 router.get('/user', async (req, res) => {
   const { userId } = req.session;

--- a/src/routes/grantee/handlers.js
+++ b/src/routes/grantee/handlers.js
@@ -1,0 +1,18 @@
+import { granteeByIdAndRegion } from '../../services/grantee';
+
+// eslint-disable-next-line import/prefer-default-export
+export async function getGrantee(req, res) {
+  try {
+    const { granteeId } = req.params;
+    // this doesn't do anything with the region passed as a url '?' param
+    // as of yet, but will eventually need to
+    const grantee = await granteeByIdAndRegion(granteeId);
+    if (!grantee) {
+      res.sendStatus(404);
+      return;
+    }
+    res.json(grantee);
+  } catch (err) {
+    res.sendStatus(500);
+  }
+}

--- a/src/routes/grantee/handlers.test.js
+++ b/src/routes/grantee/handlers.test.js
@@ -1,0 +1,53 @@
+import db, { Grantee } from '../../models';
+import { getGrantee } from './handlers';
+import { granteeByIdAndRegion } from '../../services/grantee';
+
+describe('getGrantee', () => {
+  const granteeWhere = { name: 'Mr Thaddeus Q Grantee' };
+
+  const mockResponse = {
+    attachment: jest.fn(),
+    json: jest.fn(),
+    send: jest.fn(),
+    sendStatus: jest.fn(),
+    status: jest.fn(() => ({
+      end: jest.fn(),
+    })),
+  };
+
+  afterAll(async () => {
+    await Grantee.destroy({
+      where: granteeWhere,
+    });
+
+    await db.sequelize.close();
+  });
+  it('retrieves a grantee', async () => {
+    await Grantee.create(granteeWhere);
+    const grantee = await Grantee.findOne({ where: granteeWhere });
+    const req = {
+      params: {
+        granteeId: grantee.id,
+      },
+    };
+    await getGrantee(req, mockResponse);
+    expect(mockResponse.json).toHaveBeenCalledWith(granteeWhere);
+  });
+
+  it('returns a 404 when a grantee can\'t be found', async () => {
+    const req = {
+      params: {
+        granteeId: 14565,
+      },
+    };
+    granteeByIdAndRegion.mockResolvedValue(null);
+    await getGrantee(req, mockResponse);
+    expect(mockResponse.sendStatus).toHaveBeenCalledWith(404);
+  });
+
+  it('returns a 500 on error', async () => {
+    const req = {};
+    await getGrantee(req, mockResponse);
+    expect(mockResponse.sendStatus).toHaveBeenCalledWith(500);
+  });
+});

--- a/src/routes/grantee/index.js
+++ b/src/routes/grantee/index.js
@@ -1,0 +1,9 @@
+import express from 'express';
+import {
+  getGrantee,
+} from './handlers';
+
+const router = express.Router();
+router.get('/:granteeId', getGrantee);
+
+export default router;

--- a/src/services/grantee.js
+++ b/src/services/grantee.js
@@ -1,6 +1,5 @@
 import { Grant, Grantee } from '../models';
 
-// eslint-disable-next-line import/prefer-default-export
 export async function allGrantees() {
   return Grantee.findAll({
     include: [
@@ -10,5 +9,17 @@ export async function allGrantees() {
         as: 'grants',
       },
     ],
+  });
+}
+
+export async function granteeByIdAndRegion(granteeId) {
+  return Grantee.findOne({
+    attributes: [
+      'name',
+    ],
+    where: {
+      id: granteeId,
+    },
+    raw: true,
   });
 }

--- a/src/services/grantee.test.js
+++ b/src/services/grantee.test.js
@@ -1,5 +1,5 @@
 import db, { Grantee } from '../models';
-import { allGrantees } from './grantee';
+import { allGrantees, granteeByIdAndRegion } from './grantee';
 
 describe('Grantee DB service', () => {
   afterEach(() => {
@@ -40,6 +40,13 @@ describe('Grantee DB service', () => {
       expect(foundIds).toContain(60);
       expect(foundIds).toContain(61);
       expect(foundIds).toContain(62);
+    });
+
+    it('returns a grantee by id', async () => {
+      const grantee3 = await granteeByIdAndRegion(62);
+      expect(grantee3).toStrictEqual({ name: 'grantee 3' });
+      const grantee2 = await granteeByIdAndRegion(61);
+      expect(grantee2).toStrictEqual({ name: 'grantee 2' });
     });
   });
 });


### PR DESCRIPTION
## Description of change
- Created "grantee record" page
- Created route to provide data to said page

Not much there in both cases, but they can be expanded as more Jiras are conquered.

## How to test
- View a grantee record page at /region/{**doesn't matter**}/grantee/{**granteeId**}

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-298

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [x] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
