### PR TITLE
distinguish between the types of tooltip

### DIFF
--- a/frontend/src/components/Tooltip.css
+++ b/frontend/src/components/Tooltip.css
@@ -1,17 +1,7 @@
 .smart-hub--tooltip-truncated {
+    border-bottom: 1px dashed #21272D;
     font-size: 15px;
     position: relative;
-}
-
-.smart-hub--tooltip-truncated:first-child:before {
-  background-image: url("data:image/svg+xml,%3csvg width='100%25' height='100%25' xmlns='http://www.w3.org/2000/svg'%3e%3crect width='100%25' height='100%25' fill='none' stroke='black' stroke-width='1' stroke-dasharray='6' stroke-dashoffset='5' stroke-linecap='square'/%3e%3c/svg%3e");
-  content: "";
-  height: 200%;
-  position: absolute;  
-  left: -10px;
-  right: 0;
-  bottom: 0px;
-  width: 300%;
 }
 
 .smart-hub--ellipsis {

--- a/frontend/src/components/TooltipWithCollection.css
+++ b/frontend/src/components/TooltipWithCollection.css
@@ -1,0 +1,14 @@
+.smart-hub--tooltip-truncated.smart-hub--tooltip-truncated--with-collection {
+    border-bottom: 0;
+}
+
+.smart-hub--tooltip-truncated--with-collection:first-child:before {
+    background-image: url("data:image/svg+xml,%3csvg width='100%25' height='100%25' xmlns='http://www.w3.org/2000/svg'%3e%3crect width='100%25' height='100%25' fill='none' stroke='black' stroke-width='1' stroke-dasharray='6' stroke-dashoffset='5' stroke-linecap='square'/%3e%3c/svg%3e");
+    content: "";
+    height: 200%;
+    position: absolute;  
+    left: -10px;
+    right: 0;
+    bottom: 0px;
+    width: 300%;
+  }

--- a/frontend/src/components/TooltipWithCollection.js
+++ b/frontend/src/components/TooltipWithCollection.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { v4 as uuidv4 } from 'uuid';
 import Tooltip from './Tooltip';
+import './TooltipWithCollection.css';
 
 export default function TooltipWithCollection({ collection, collectionTitle }) {
   if (!collection || collection.length === 0) {
@@ -16,7 +17,7 @@ export default function TooltipWithCollection({ collection, collectionTitle }) {
   const tags = (collection).map((member) => (
     <span
       key={uuidv4()}
-      className="smart-hub--tooltip-truncated"
+      className="smart-hub--tooltip-truncated smart-hub--tooltip-truncated--with-collection"
     >
       {member}
       &nbsp;


### PR DESCRIPTION
## Description of change

### Issue:
![Screen Shot 2021-10-18 at 8 45 26 AM](https://user-images.githubusercontent.com/3288586/137733241-47d92e65-28bb-412c-89ee-316b31cb4c98.png)
### Solution:
![Screen Shot 2021-10-18 at 8 45 54 AM](https://user-images.githubusercontent.com/3288586/137733347-052d77ee-f12b-4949-8a6b-b65c58c376a4.png)

Tooltips that will overflow require different line stylings than ones that won't (the svg box-background-image technique won't work if we can't hide the sides, like when there is a small amount of information in the box)

## How to test
On the activity reports, view the table. If you have overflow information in one of the "collections" you will see a dashed line, with no left and right sides visible. This will also be true for the "approver count" tooltip.

## Issue(s)

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
